### PR TITLE
Passing a single item object to Order\Entity\Item\Edit::updateStatus errors

### DIFF
--- a/src/Message/Mothership/Commerce/Order/Entity/Item/Edit.php
+++ b/src/Message/Mothership/Commerce/Order/Entity/Item/Edit.php
@@ -45,7 +45,7 @@ class Edit implements DB\TransactionalInterface
 		$status = $this->_statuses->get($statusCode);
 
 		if (!is_array($items)) {
-			$items = (array) $items;
+			$items = array($items);
 		}
 
 		foreach ($items as $key => $item) {


### PR DESCRIPTION
If you pass in an instance of `Message\Mothership\Commerce\Order\Entity\Item\Item` into `Message\Mothership\Commerce\Order\Entity\Item\Edit::updateStatus` the item object gets converted to an array and so fails `if (!($item instanceof Item)) {` in the loop.
