### PR TITLE
Porting: Some order status codes are no longer used

### DIFF
--- a/src/Message/Mothership/Commerce/Task/Porting/Order/OrderSummary.php
+++ b/src/Message/Mothership/Commerce/Task/Porting/Order/OrderSummary.php
@@ -29,11 +29,7 @@ class OrderSummary extends Porting
 						WHEN 4 THEN 500
 						WHEN 5 THEN 800
 						WHEN 6 THEN 1000
-						WHEN 9 THEN 1500
-						WHEN 10 THEN 1500
-						WHEN 99 THEN 2100
 						WHEN -2 THEN -300
-						WHEN -1 THEN -100
 						ELSE 1000
 					END AS status_code,
 					order_summary.user_id AS user_id,


### PR DESCRIPTION
These throw an exception:

```
[2013-11-05 10:35:45] errors.ERROR: 500 error on website frontend {"exception":"[object] (InvalidArgumentException: Status code `2100` not set on collection at /var/www/uniform_wares/releases/20131104174507/vendor/message/cog-mothership-commerce/src/Message/Mothership/Commerce/Order/Status/Collection.php:73)"} []
```
