### PR TITLE
Removing __wakeup method from Product\Image\Image

### DIFF
--- a/src/Message/Mothership/Commerce/Product/Image/Image.php
+++ b/src/Message/Mothership/Commerce/Product/Image/Image.php
@@ -76,11 +76,7 @@ class Image implements ResizableInterface
 			'locale',
 			'options',
 			'product',
+			'_file',
 		);
-	}
-
-	public function __wakeup()
-	{
-		$this->file = \Message\Cog\Service\Container::get('file_manager.file.loader')->getByID($this->id);
 	}
 }


### PR DESCRIPTION
This was causing an issue where:
- During session startup, the __wakeup() method was called for images loaded on products that were in the basket in the session
- The __wakeup() method was retrieving the file loader from the service container
- Because the file loader (for some reason) was dependency injected with the current user, infinite recursion occured
