### PR TITLE
Added "new" to ArrayIterator call in Product\Unit\Collection

### DIFF
--- a/src/Product/Unit/Collection.php
+++ b/src/Product/Unit/Collection.php
@@ -97,7 +97,7 @@ class Collection implements \ArrayAccess, \IteratorAggregate, \Countable
 	{
 		$this->load();
 
-		return \ArrayIterator($this->_items);
+		return new \ArrayIterator($this->_items);
 	}
 
 	public function load($showOutOfStock = true, $showInvisibleUnits = true)


### PR DESCRIPTION
Was getting an error when trying to loop through $product->units, as it was trying to call ArrayIterator as a function rather than a class
