### PR TITLE
Event dispatching when updating order item status is incorrect

### DIFF
--- a/src/Order/Entity/Item/Edit.php
+++ b/src/Order/Entity/Item/Edit.php
@@ -64,6 +64,7 @@ class Edit implements DB\TransactionalInterface
 		}
 
 		// Filter out any falsey values
+		$items  = ($items instanceof Collection) ? $items->all() : $items;
 		$items  = array_filter($items);
 		$orders = [];
 

--- a/tests/Order/Entity/Item/EditTest.php
+++ b/tests/Order/Entity/Item/EditTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Message\Mothership\Commerce\Test\Order\Entity\Item;
+
+use Message\Mothership\Commerce\Order\Entity\Item;
+use Message\Mothership\Commerce\Order\Status\Status;
+
+use Message\Cog\Test\Event\FauxDispatcher;
+
+class EditTest extends \PHPUnit_Framework_TestCase
+{
+	protected $_trans;
+	protected $_statuses;
+	protected $_dispatcher;
+	protected $_user;
+	protected $_edit;
+
+	public function setUp()
+	{
+		$this->_trans = $this->getMockBuilder('\\Message\\Cog\\DB\\Transaction')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->_statuses   = $this->getMock('\\Message\\Mothership\\Commerce\\Order\\Status\\Collection');
+		$this->_user       = $this->getMock('\\Message\\User\\User');
+		$this->_dispatcher = new FauxDispatcher;
+		$this->_edit       = new Item\Edit($this->_trans, $this->_dispatcher, $this->_statuses, $this->_user);
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 * @expectedExceptionMessage item status `100` does not exist
+	 */
+	public function testUpdateStatusThrowsExceptionOnUndefinedStatus()
+	{
+		$this->_edit->updateStatus(new Item\Item, 100);
+	}
+
+	public function testUpdateStatusIgnoresFalseyValues()
+	{
+		$status = new Status(100, 'Something');
+
+		$this->_statuses
+			->expects($this->any())
+			->method('exists')
+			->with(100)
+			->will($this->returnValue(true));
+
+		$this->_statuses
+			->expects($this->any())
+			->method('get')
+			->with(100)
+			->will($this->returnValue($status));
+
+		$item = new Item\Item;
+		$item->status = $status;
+
+		$items = [
+			null,
+			$item,
+			false
+		];
+
+		$this->assertFalse($this->_edit->updateStatus($items, 100));
+
+		$collection = new Item\Collection;
+
+		$collection->append($item); // this method don't allow any falsey values anyways
+
+		$this->assertFalse($this->_edit->updateStatus($collection, 100));
+	}
+}


### PR DESCRIPTION
In the `Edit` decorator for `Order\Entity\Item`, in `updateStatus()` [an event is fired when the status is changed](https://github.com/messagedigital/cog-mothership-commerce/blob/fdf3362a378b96455e50ad498a44192d82be6ceb/src/Order/Entity/Item/Edit.php#L102-L108).

This is causing issues because this method now takes multiple items and it is possible that the items could be from different orders. The event takes an order as it's only dependency in the constructor.

Currently only one event is being dispatched no matter how many items from how many orders are passed in.

Instead, we should collect all the individual orders when we loop over the items to update and then fire a separate event for each of them before returning.

This is the cause of https://github.com/messagedigital/ms-demo/issues/105
