### PR TITLE
Remove exception when setting existing Order\Metadata key

### DIFF
--- a/src/Order/Metadata.php
+++ b/src/Order/Metadata.php
@@ -105,12 +105,13 @@ class Metadata implements \ArrayAccess, \IteratorAggregate, \Countable
 	}
 
 	/**
-	 * Set a metadata value.
+	 * Set a metadata value. If a metadata value with the same key has
+	 * previously been set, it will be overwritten with the new value.
 	 *
 	 * @param  string $name  The metadata key name
 	 * @param  mixed  $value The metadata value
 	 *
-	 * @return Assembler     Returns $this for chainability
+	 * @return Metadata      Returns $this for chainability
 	 */
 	public function set($name, $value)
 	{


### PR DESCRIPTION
It doesn't make sense to be so defensive. We should allow the metadata values to be changed, there isn't much reason why not.

Also made set() return $this so it can be called as a chained method.

This was causing this issue: https://trello.com/c/vtFjlath/470-urgent-service-centre-assessments-leading-to-error-messages
