### PR TITLE
Order\Assembler: Fix incorrect property name

### DIFF
--- a/src/Order/Assembler.php
+++ b/src/Order/Assembler.php
@@ -182,7 +182,7 @@ class Assembler
 			$this->_prepareEntity($name, $entity);
 		}
 
-		$this->_order->{$name}->remove($entity);
+		$this->_order->{$name}->remove($entity->id);
 
 		return $this->dispatchEvent();
 	}


### PR DESCRIPTION
#### What does this do?

Fixes an issue where the property name called for the "temporary ID property" was set incorrectly, meaning the functionality never worked. I spotted this on working in EPOS but it may well be causing issues with checkout and repairs in UW.
#### How should this be manually tested?

Use this branch and test checkout and the process of sending a repair to fulfillment. Check order for data integrity and everything should look as it should.

Adding an address of type `delivery` if an address of that type already exists should overwrite that address.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
