### PR TITLE
Fixed loader issue by adding order loader to entity loaders

### DIFF
--- a/src/Order/Loader.php
+++ b/src/Order/Loader.php
@@ -48,14 +48,6 @@ class Loader
 		return $return;
 	}
 
-	protected function _prepareEntities()
-	{
-		foreach ($this->_entities as $entity) {
-			$loader = $entity->getLoader();
-			$loader->setOrderLoader($this);
-		}
-	}
-
 	/**
 	 * Get the loader for a specific entity.
 	 *
@@ -339,5 +331,18 @@ class Loader
 		});
 
 		return $returnArray ? $orders : reset($orders);
+	}
+
+	/**
+	 * Prepares entities by setting their loaders' order loader to $this.
+	 * This is necessary to make sure the entity loaders will always have an
+	 * order loader.
+	 */
+	protected function _prepareEntities()
+	{
+		foreach ($this->_entities as $entity) {
+			$loader = $entity->getLoader();
+			$loader->setOrderLoader($this);
+		}
 	}
 }


### PR DESCRIPTION
#### What does this do?

When we load order entities, we use the `order.loader` to access them. The loader sets the order loader on the entity loader and so the entity can always load the order.

When we use the `CollectionOrderLoader` (`$order->entityName`), the order loader is never set on the entity loader and so, if we do not pass in an order, the entity will not be able to load the order. This is the case in returns, where we found this bug.

To fix it,  in the constructor of the order loader, we now call `_prepareEntities`, a method which loops through all entities and sets their loaders' order loader.
#### How should this be manually tested?

Compare the entity loaders when calling `entityName.loader` (which has always had the order loader) and `$order->entityName->getLoader()` (which _didn't_ have the order loader but should now!).
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
