### PR TITLE
Feature/serialized loader bug

### DIFF
--- a/src/Order/Entity/CollectionOrderLoader.php
+++ b/src/Order/Entity/CollectionOrderLoader.php
@@ -27,11 +27,6 @@ class CollectionOrderLoader implements CollectionInterface
 		$this->_loader     = $loader;
 	}
 
-	public function __sleep()
-	{
-		return array('_collection', '_loaded', '_order');
-	}
-
 	public function __clone()
 	{
 		$this->_collection = clone $this->_collection;

--- a/src/Order/Entity/CollectionOrderLoader.php
+++ b/src/Order/Entity/CollectionOrderLoader.php
@@ -156,6 +156,10 @@ class CollectionOrderLoader implements CollectionInterface
 				throw new \LogicException('Cannot load entity collection as no order has been set yet');
 			}
 
+			if (!$this->_loader) {
+				throw new \LogicException('Loader is not set so cannot load items for `' . get_class($this->_collection) . '`');
+			}
+
 			if ($this->_order->id && is_int($this->_order->id) && $items = $this->_loader->getByOrder($this->_order)) {
 				foreach ($items as $item) {
 					$this->_collection->append($item);

--- a/src/Order/Entity/CollectionOrderLoader.php
+++ b/src/Order/Entity/CollectionOrderLoader.php
@@ -151,10 +151,6 @@ class CollectionOrderLoader implements CollectionInterface
 				throw new \LogicException('Cannot load entity collection as no order has been set yet');
 			}
 
-			if (!$this->_loader) {
-				throw new \LogicException('Loader is not set so cannot load items for `' . get_class($this->_collection) . '`');
-			}
-
 			if ($this->_order->id && is_int($this->_order->id) && $items = $this->_loader->getByOrder($this->_order)) {
 				foreach ($items as $item) {
 					$this->_collection->append($item);


### PR DESCRIPTION
Requires https://github.com/messagedigital/cog/pull/354

No longer loses the loader when serialized as the __sleep method has been moved onto the connection object.
