### PR TITLE
Making order implement `DB\TransactionalInterface`

### DIFF
--- a/src/Order/Create.php
+++ b/src/Order/Create.php
@@ -231,8 +231,6 @@ class Create implements DB\TransactionalInterface
 		);
 
 		$order = $event->getOrder();
-		// do we need this?
-		$this->_trans = $event->getTransaction();
 
 		// add CREATE_COMPLETE event to when transaction is committed
 		$loader = $this->_loader;


### PR DESCRIPTION
#### What does this do?
- Adds the method `setTransaction()` to the order create decorator, so that we can create an order within another transaction.
- Adds `transOverridden`, so that only if the transaction has not been overridden, it will be committed.
- Fires `CREATE_COMPLETE` event when transaction is committed.
#### How should this be manually tested?

Check out this branch and try to create orders as part of a transaction (see standalone returns with exchange items on epos for this), create normal orders to make sure this change doesn't break anything.
#### Related PRs / Issues / Resources?

This is necessary for the returns epos update: https://github.com/messagedigital/cog-mothership-returns/tree/feature/epos-updates
#### Anything else to add? (Screenshots, background context, etc)
