### PR TITLE
Fix out of stock bug on checkout

### DIFF
--- a/src/Order/Basket/EventListener/AttachUserListener.php
+++ b/src/Order/Basket/EventListener/AttachUserListener.php
@@ -11,7 +11,6 @@ use Message\Cog\Event\SubscriberInterface;
 use Message\Cog\Event\EventListener as BaseListener;
 use Message\Mothership\Commerce\Order\Entity\Address\Address;
 use Message\Cog\Event\Event as BaseEvent;
-use Message\Mothership\Ecommerce;
 use Message\User\User;
 use Message\User\AnonymousUser;
 
@@ -37,9 +36,6 @@ class AttachUserListener extends BaseListener implements SubscriberInterface
 			),
 			UserEvents\Event::LOGOUT => array(
 				array('addUserToOrder')
-			),
-			Ecommerce\Event::EMPTY_BASKET => array(
-				array('addUserToOrder'),
 			),
 		);
 	}


### PR DESCRIPTION
#### What does this do?

We had a bug (messagedigital/cog-mothership-ecommerce#209) in which, when you order a unit with a stock level of 1, you get a weird warning flash on the confirmation page, saying one of the products in your basket has run out of stock and had to be removed.

This is why:
1. We [create the order Ecommerce](https://github.com/messagedigital/cog-mothership-ecommerce/blob/develop/src/Controller/Checkout/Complete.php#L41-L43), stock levels for the ordered items are decremented, order was sent successfully. 
2. In [Ecommerce](https://github.com/messagedigital/cog-mothership-ecommerce/blob/develop/src/Controller/Checkout/Complete.php#L102-L106), after creating the order, the basket session is cleared. Directly before that an `EMPTY_BASKET` event is fired.
3. In Commerce, we remove and (re-)add user details to the basket on `LOGIN`, `LOGOUT` and `EMPTY_BASKET`. I think this is because we probably wanted to reinitialise the basket and add the user again _after_ the basket is cleared for the old order. However, the event is fired before we clear the basket, so I don't think listening to `EMPTY_BASKET` has ever actually done what it was meant to do.
4. Because we use the `Order\Assembler` to add or remove the user on `LOGIN`, `LOGOUT` and `EMPTY_BASKET`, this then lead to `Order\Events::ASSEMBLER_UPDATE` to be fired. On this event, the  [StockCheckListener](https://github.com/messagedigital/cog-mothership-commerce/blob/develop/src/Order/EventListener/Assembler/StockCheckListener.php) checks stock levels of all basket items and items that are out of stock are removed from the basket and a flash message is added.

So, although the order is already placed and everything worked fine, because the basket is not cleared yet, the now out-of-stock item is still in there and gets checked.
To fix it, I just removed listening to `EMPTY_BASKET`. I am not sure how this could affect the rest of the system... I have gone through old commits, looked at the commit messages to find out what the reason for adding this event was, but all I could find was a "Adding events" commit message by Danny :(
Looking at it logically, I can't think of anything that could break due to this change... There is nothing that we would want to change in the order, once it's created and the only thing we want to do with the basket, before it's deleted, is make sure it's also removed from the db (See [PersistenceListener](https://github.com/messagedigital/cog-mothership-commerce/blob/develop/src/Order/Basket/EventListener/PersistenceListener.php))...
So I am pretty sure it's safe to just remove that event. Also that will remove one of the two direct references to ecommerce in commerce (see #340).
#### How should this be manually tested?

Place a few orders, play around with it, look at the basket and events with and without that change... Make sure all data in the db is still correct.
#### Related PRs / Issues / Resources?

Issue: messagedigital/cog-mothership-ecommerce#209
#### Anything else to add? (Screenshots, background context, etc)
