### PR TITLE
Check to see if $this->_file on Product\Image\Image is NULL rather than if it is falsy

### DIFF
--- a/src/Product/Image/Image.php
+++ b/src/Product/Image/Image.php
@@ -67,7 +67,7 @@ class Image implements ResizableInterface
 
 	protected function _loadFile()
 	{
-		if ((null !== $this->_file) && !$this->_fileLoader) {
+		if (null !== $this->_file) {
 			return;
 		}
 


### PR DESCRIPTION
#### What does this do?

Fixes https://trello.com/c/dgM7daCp/509-promotion-codes-not-working

When adding a discount to the order, a serialization issue was being caused when saving the basket. The exception was being thrown because

```
    $this->_file = $this->_fileLoader->getByID($this->fileID);
```

was returning false, and so it would try to load the file again after it had been serialized.
#### How should this be manually tested?

Attempt to complete an order with a discount on the `develop` commerce branch, then clear your session/open a new incognito window, and try it again with this branch
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
