### PR TITLE
Parse field names to be valid, store in hidden form fields

### DIFF
--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -649,11 +649,11 @@ class Edit extends Controller
 					$choices[$choice] = $choice;
 				}
 
-				$fieldName = preg_replace('/[^a-z0-9]-_:/i', '-', $type);
+				$fieldName = preg_replace('/[^a-z0-9]/i', '_', $type);
 
 				$optionForm->add($fieldName, 'datalist', ucfirst($type), [
 					'choices' => $choices,
-					'data'    => ($unit->options[$type]) ?: null,
+					'data'    => (!empty($unit->options[$type])) ? $unit->options[$type] : null,
 				])->val()->optional();
 
 				$optionForm->add($fieldName . self::HIDDEN_SUFFIX, 'hidden', $fieldName, [


### PR DESCRIPTION
#### What does this do?

Fixes https://github.com/messagedigital/union-music-store/issues/172

Symfony form was throwing a hissy because there was a unit option name that had a space in it, and since these were used to set the name of the form field it would throw an exception (it only accepts letters, digits, underscores, hyphens and colons, and not html or url encoding). This fix replaces any spaces with hyphens and stores the option name in a hidden field, which is then used when rebuilding the query.

Also I swapped the drop downs for datalists so users can add their new values when editing units.
#### How should this be manually tested?

Create a new unit with an option that has a special character in it, and save it. Then reload the units tab (this is where it would have errored), and then save a change to the units.

To test on Union you might need to use the compatibility branch
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
