### PR TITLE
fixed image loading when no images on product

### DIFF
--- a/src/Product/Image/Loader.php
+++ b/src/Product/Image/Loader.php
@@ -60,7 +60,7 @@ class Loader
 
 		$images = $this->_load($dataSet->flatten());
 
-		return $images ?: false;
+		return $images ?: [];
 	}
 
 	/**
@@ -81,7 +81,7 @@ class Loader
 
 		$images = $this->_load($dataSet->flatten(), $product);
 
-		return $images ?: false;
+		return $images ?: [];
 	}
 
 	protected function _load(array $ids, Product $product = null)


### PR DESCRIPTION
#### What does this do?

fixes error when loading getting product images from product with no images
#### How should this be manually tested?

try on tonic where there are lots of products with no images. ensure no other breaks.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
