### PR TITLE
Add setActualPrice for use in EPOS

### DIFF
--- a/src/Order/Assembler.php
+++ b/src/Order/Assembler.php
@@ -288,7 +288,7 @@ class Assembler
 		// Remove the item as many times needed to make the count equal the given
 		// quantity
 		if ($quantity < $unitCount) {
-			for ($i = $unitCount ; $i > $quantity; $i--) {
+			for ($i = $unitCount; $i > $quantity; $i--) {
 				$this->_order->items->remove(array_shift($items));
 			}
 		}
@@ -315,6 +315,37 @@ class Assembler
 	public function updateQuantity(Unit $unit, $quantity = 1)
 	{
 		return $this->setQuantity($unit, $quantity);
+	}
+
+	/*
+	 * Update the actual price of items for a given unit on the order being
+	 * assembled.
+	 *
+	 * @param  Unit $unit     The unit to change quantity for
+	 * @param  int  $quantity The quantity to set
+	 *
+	 * @return Assembler      Returns $this for chainability
+	 */
+	public function setActualPrice(Unit $unit, $actualPrice)
+	{
+		// Disable event dispatching while we update the quantities
+		$this->_dispatchEvents = false;
+
+		$row       = $this->_order->items->getRows()[$unit->id];
+		$items     = $row->all();
+
+		// if the actual prices are the same then return
+		if ($row->first()->actualPrice === $actualPrice) {
+			return $this;
+		}
+
+		foreach($items as $item) {
+			$item->actualPrice = $actualPrice;
+		}
+
+		$this->_dispatchEvents = true;
+
+		return $this->dispatchEvent();
 	}
 
 	public function addPayment(Payment\MethodInterface $paymentMethod, $amount, $reference)


### PR DESCRIPTION
#### What does this do?

This adds back in the setActualPrice method which is used in EPOS when overriding a price.
#### How should this be manually tested?

In EPOS change a price of a product and test this value is used correctly in the sale.
#### Related PRs / Issues / Resources?

https://github.com/messagedigital/cog-mothership-commerce/pull/374/files#diff-c02d9e574739290127197f675d102c1aR326
#### Anything else to add? (Screenshots, background context, etc)
