### PR TITLE
Flush orders that are stuck with an incomplete status

### DIFF
--- a/src/Bootstrap/Tasks.php
+++ b/src/Bootstrap/Tasks.php
@@ -41,6 +41,8 @@ class Tasks implements TasksInterface
 
 		$tasks->add(new Product\Stock\StockSnapshot('commerce:stock:snapshot'), 'Creates a snapshot of current stock levels');
 
+		$tasks->add(new Task\Order\FlushOrders('commerce:flush_orders'), 'Completes orders that are stuck in fulfillment');
+
 		$tasks->add(new Product\Barcode\GenerateTask('commerce:barcode:generate'), 'Creates barcode images for all units in the database');
 
 	}

--- a/src/Order/EventListener/StatusListener.php
+++ b/src/Order/EventListener/StatusListener.php
@@ -70,12 +70,12 @@ class StatusListener extends BaseListener implements SubscriberInterface
 
 		// Skip if no status was set
 		if (is_null($orderStatus)) {
-			return false;
+			return;
 		}
 
 		// Skip if the status hasn't changed
 		if ($orderStatus === $order->status->code) {
-			return false;
+			return;
 		}
 
 		$edit = $this->get('order.edit');

--- a/src/Task/Order/FlushOrders.php
+++ b/src/Task/Order/FlushOrders.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Message\Mothership\Commerce\Task\Order;
+
+use Message\Cog\Console\Task\Task;
+
+class FlushOrders extends Task
+{
+	public function process()
+	{
+		$orderIDQuery = $this->get('db.query.builder.factory')->getQueryBuilder()
+			->select('order_id')
+			->from('order_summary')
+			->where('order_summary.status_code IN (?ji)', [[500,800]])
+		;
+
+		$itemStatuses = $this->get('db.query.builder.factory')->getQueryBuilder()
+			->select(['order_item_status.order_id, item_id, status_code'])
+			->from('order_item_status')
+			->join('order_ids', 'order_ids.order_id = order_item_status.order_id', $orderIDQuery)
+			->getQuery()
+			->run()
+		;
+
+		$data = [];
+		$completed = [];
+
+		foreach ($itemStatuses as $status) {
+			if (!array_key_exists($status->order_id, $data)) {
+				$data[$status->order_id] = [];
+			}
+			if (!array_key_exists($status->item_id, $data[$status->order_id])) {
+				$data[$status->order_id][$status->item_id] = [];
+			}
+			$data[$status->order_id][$status->item_id][] = $status->status_code;
+		}
+
+		foreach ($data as $orderID => $items) {
+			$orderComplete = true;
+			foreach ($items as $statuses) {
+				$itemComplete = false;
+				foreach ($statuses as $code) {
+					if ($code >= 1000) {
+						$itemComplete = true;
+						continue;
+					}
+				}
+				if (false === $itemComplete) {
+					$orderComplete = false;
+					continue;
+				}
+			}
+			if ($orderComplete) {
+				$this->writeln('Order ' . $orderID . ' complete');
+				$completed[] = $orderID;
+			} else {
+				$this->writeln('<info>Order ' . $orderID . ' not complete</info>');
+			}
+		}
+
+		$this->get('db.query')->run("
+			UPDATE
+				order_summary
+			SET
+				status_code = :statusCode?i
+			WHERE
+				order_id IN (:orderIDs?ji)
+		", [
+			'statusCode' => 1000,
+			'orderIDs'   => $completed,
+		]);
+	}
+}


### PR DESCRIPTION
#### What does this do?

Complete orders that are stuck in processing stages despite all the individual items having a completed status. This is merely a data cleaning task and not a fix for the deeper issue which requires more investigation
#### How should this be manually tested?

Run `bin/cog task:run commerce:flush_orders --env=local-thomas`. Check that any stuck orders are set to completed
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
