### PR TITLE
Missing image bugfix for Product Dashboard

### DIFF
--- a/src/Product/Image/Image.php
+++ b/src/Product/Image/Image.php
@@ -32,14 +32,22 @@ class Image implements ResizableInterface
 		$this->authorship
 			->disableUpdate(); // remove when making update class
 	}
-	
+
 	public function getUrl()
 	{
+		if (!$this->getFile()) {
+			return null;
+		}
+
 		return $this->getFile()->getUrl();
 	}
 
 	public function getAltText()
 	{
+		if (!$this->getFile()) {
+			return null;
+		}
+
 		return $this->getFile()->getAltText();
 	}
 


### PR DESCRIPTION
#### What does this do?

Returns null if `getFile()` on product image returns nothing. I was getting an `non-object` error on the product dashboard. I'm think this is probably more down to broken data, but this fix should make the file loading a little more stable
#### How should this be manually tested?
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
