### PR TITLE
Fix for broken payment page

### DIFF
--- a/resources/view/order/detail/payment/refund-detail.html.twig
+++ b/resources/view/order/detail/payment/refund-detail.html.twig
@@ -19,7 +19,7 @@
 			<dt>{{ 'ms.commerce.order.refund.payment'|trans }}</dt>
 				<dd>
 					{% if refund.refund.payment %}
-						#{{ refund.refund.payment }}
+						#{{ refund.refund.payment.id }}
 					{% else %}
 						<em>Unknown</em>
 					{% endif %}


### PR DESCRIPTION
In the order overview when looking at payments for a refunded order, I was getting a conversion to string error. This fixes that.
