### PR TITLE
Migration to change value datatype on product_detail table

### DIFF
--- a/resources/migrations/_1424772091_ChangeProductDetailValueType.php
+++ b/resources/migrations/_1424772091_ChangeProductDetailValueType.php
@@ -1,0 +1,16 @@
+<?php
+
+use Message\Cog\Migration\Adapter\MySQL\Migration;
+
+class _1424772091_ChangeProductDetailValueType extends Migration
+{
+	public function up()
+	{
+		$this->run("ALTER TABLE product_detail MODIFY `value` TEXT;");
+	}
+
+	public function down()
+	{
+		$this->run("ALTER TABLE product_detail MODIFY `value` VARCHAR(255);");
+	}
+}


### PR DESCRIPTION
#### What does this do?

Changes the datatype on the product detail value column to TEXT. For some reason (most likely stupidity) when I initially set up the table I had it set to VARCHAR(255) which meant that it was getting cut off after saving.
#### How should this be manually tested?

Run the migrations and try to create an apparel product with a whole load of sizing text
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
