### PR TITLE
Currency form markup and quantity selector

### DIFF
--- a/resources/view/currency_form.html.twig
+++ b/resources/view/currency_form.html.twig
@@ -1,4 +1,15 @@
-{{ form_start(form) }}
-{{ form_rest(form) }}
-<button class="button">Go</button>
-{{ form_end(form) }}
+<div class="currency-selector">
+	<div class="set-currency {{ currency }}">{{ currency }}</div>
+	<label>Currency</label>
+	<div class="currency-options">
+		{{ form_start(form) }}
+		{% for c in form.currency %}
+		    <div class="field inline">
+			{{ form_label(c, c.vars.value, { 'label_attr': {'class': c.vars.value}}) }}
+			{{ form_widget(c) }}
+		    </div>
+		{% endfor %}
+			<button class="button">Go</button>
+		{{ form_end(form) }}
+	</div>
+</div>

--- a/src/Controller/Module/CurrencySelect.php
+++ b/src/Controller/Module/CurrencySelect.php
@@ -17,7 +17,9 @@ class CurrencySelect extends Controller
 			'expanded' => true,
 		]);
 
-		return $this->render('Message:Mothership:Commerce::currency_form', ['form' => $form]);
+		return $this->render('Message:Mothership:Commerce::currency_form', [
+			'form' => $form, 'currency' => $this->get('currency'),
+		]);
 	}
 
 	public function process()

--- a/src/Controller/Module/ProductSelector.php
+++ b/src/Controller/Module/ProductSelector.php
@@ -115,7 +115,7 @@ class ProductSelector extends Controller
 			]);
 		// Otherwise, add a select box to select the unit
 		} else {
-			$form->add('unit_id', new ProductUnitInStockOnlyChoiceType, $this->trans('ms.commerce.product.selector.unit.label'), [
+			$form->add('unit_id', 'unit_choice', $this->trans('ms.commerce.product.selector.unit.label'), [
 				'choices'      => $choices,
 				'units'        => $units,
 				'oos'          => array_keys($oosUnits),

--- a/src/Controller/Module/ProductSelector.php
+++ b/src/Controller/Module/ProductSelector.php
@@ -30,7 +30,7 @@ class ProductSelector extends Controller
 	 *                                      
 	 * @return Message\Cog\HTTP\Response    Response object
 	 */
-	public function index(Product $product, array $options = [], $showVariablePricing = false)
+	public function index(Product $product, array $options = [], $showVariablePricing = false, $showQuantitySelector = false)
 	{
 		$options  = array_filter($options);
 		$units    = $this->_getAvailableUnits($product, $options);
@@ -46,7 +46,7 @@ class ProductSelector extends Controller
 		return $this->render('Message:Mothership:Commerce::product:product-selector', array(
 			'product'     => $product,
 			'units'       => $units,
-			'form'        => $this->_getForm($product, $options, $showVariablePricing),
+			'form'        => $this->_getForm($product, $options, $showVariablePricing, $showQuantitySelector),
 		));
 	}
 
@@ -58,27 +58,37 @@ class ProductSelector extends Controller
 		if ($form->isValid() && $data = $form->getFilteredData()) {
 			$basket   = $this->get('basket');
 			$unit     = $product->getUnit($data['unit_id']);
-			$item     = new Order\Entity\Item\Item;
-			$item->order         = $basket->getOrder();
-			$item->stockLocation = $this->get('stock.locations')->get('web');
-			$item->populate($unit);
 
-			$item = $this->get('event.dispatcher')->dispatch(
-				Events::PRODUCT_SELECTOR_PROCESS,
-				new Event\ProductSelectorProcessEvent($form, $product, $item)
-			)->getItem();
+			$fail = false;
+			for($i = 0; $i < $data['quantity']; ++$i) {
+				$item     = new Order\Entity\Item\Item;
+				$item->order         = $basket->getOrder();
+				$item->stockLocation = $this->get('stock.locations')->get('web');
+				$item->populate($unit);
 
-			if ($basket->addItem($item)) {
-				$this->addFlash('success', 'The item has been added to your basket');
-			} else {
-				$this->addFlash('error', 'The item could not be added to your basket');
+				$item = $this->get('event.dispatcher')->dispatch(
+					Events::PRODUCT_SELECTOR_PROCESS,
+					new Event\ProductSelectorProcessEvent($form, $product, $item)
+				)->getItem();
+
+				if (!$basket->addItem($item)) {
+					$this->addFlash('error', 'An item could not be added to your basket');
+					$fail = true;
+					break;
+				}
+
 			}
+
+			if (!$fail) {
+				$this->addFlash('success', 'Item added to basket');
+			}
+
 		}
 
 		return $this->redirectToReferer();
 	}
 
-	protected function _getForm(Product $product, array $options = [], $showVariablePricing = false)
+	protected function _getForm(Product $product, array $options = [], $showVariablePricing = false, $showQuantitySelector = false)
 	{
 		$form = $this->get('form')
 			->setName('select_product')
@@ -114,7 +124,14 @@ class ProductSelector extends Controller
 			]);
 		}
 
-		$form->add('quantity', 'hidden', null, ['data' => 1]);
+		if ($showQuantitySelector) {
+			$form->add('quantity', 'choice', null, [
+				'data'    => 1,
+				'choices' => array_combine(range(1, 10), range(1, 10)),
+			]);
+		} else {
+			$form->add('quantity', 'hidden', null, ['data' => 1]);
+		}
 
 		$form = $this->get('event.dispatcher')->dispatch(
 			Events::PRODUCT_SELECTOR_BUILD,

--- a/src/Controller/Module/ProductSelector.php
+++ b/src/Controller/Module/ProductSelector.php
@@ -59,7 +59,6 @@ class ProductSelector extends Controller
 			$basket   = $this->get('basket');
 			$unit     = $product->getUnit($data['unit_id']);
 			$item     = new Order\Entity\Item\Item;
-
 			$item->order         = $basket->getOrder();
 			$item->stockLocation = $this->get('stock.locations')->get('web');
 			$item->populate($unit);
@@ -114,6 +113,8 @@ class ProductSelector extends Controller
 				'show_pricing' => $showVariablePricing && $product->hasVariablePricing(),
 			]);
 		}
+
+		$form->add('quantity', 'hidden', null, ['data' => 1]);
 
 		$form = $this->get('event.dispatcher')->dispatch(
 			Events::PRODUCT_SELECTOR_BUILD,

--- a/src/Form/Extension/CommerceExtension.php
+++ b/src/Form/Extension/CommerceExtension.php
@@ -43,6 +43,7 @@ class CommerceExtension extends AbstractExtension
 			new Type\CurrencySelect($this->_currencies),
 			new Type\PriceGroup($this->_priceTypes),
 			new Type\PriceForm($this->_currencies),
+			new Type\UnitChoice,
 		];
 	}
 }

--- a/src/Form/Extension/Type/UnitChoice.php
+++ b/src/Form/Extension/Type/UnitChoice.php
@@ -1,18 +1,14 @@
 <?php
 
-namespace Message\Mothership\Commerce\Field;
+namespace Message\Mothership\Commerce\Form\Extension\Type;
 
-use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
 
-/**
- * @deprecated Use unit_choice Message\Mothership\Commerce\Form\Type\UnitChoice
- */
-class ProductUnitInStockOnlyChoiceType extends AbstractType
+class UnitChoice extends Form\AbstractType
 {
-	protected $_container;
 
 	public function setDefaultOptions(OptionsResolverInterface $resolver)
 	{
@@ -42,9 +38,11 @@ class ProductUnitInStockOnlyChoiceType extends AbstractType
 		return 'choice';
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function getName()
 	{
-		return 'ms_product_unit_in_stock';
+		return 'unit_choice';
 	}
 }
-


### PR DESCRIPTION
Adds a quantity selector. To get the selector you have to add `showquantitySelector: true` to the twig controller call.

Also adds better markup for mothership's currency selector. Should allow better styling.