### PR TITLE
Migration to make product_image_option correct

### DIFF
--- a/resources/migrations/_1426241749_ProductImageOptionsImageIDFix.php
+++ b/resources/migrations/_1426241749_ProductImageOptionsImageIDFix.php
@@ -1,0 +1,16 @@
+<?php
+
+use Message\Cog\Migration\Adapter\MySQL\Migration;
+
+class _1426241749_ProductImageOptionsImageIDFix extends Migration
+{
+	public function up()
+	{
+		$this->run("ALTER TABLE product_image_option MODIFY `image_id` VARCHAR(32);");
+	}
+
+	public function down()
+	{
+		$this->run("ALTER TABLE product_image_option MODIFY `image_id` INT;");
+	}
+}


### PR DESCRIPTION
This makes the image options use the correct id. Before it was trying to join a varchar onto an int. Surprised SQL just didn't say 'no'.