### PR TITLE
Namespace currency cookie

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -1167,7 +1167,6 @@ class Services implements ServicesInterface
 	public function setupCurrencies($services)
 	{
 		$services['currency'] = function($c) {
-			de($c['currency.resolver']->getCurrency());
 			return $c['currency.resolver']->getCurrency();
 		};
 

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -1189,8 +1189,11 @@ class Services implements ServicesInterface
 		});
 
 		$services['currency.cookie.name'] = function($c) {
-			if(!(isset($c['cfg']->currency) && isset($c['cfg']->currency->cookieName))) {
-				return 'ms.commerce.currency';
+			$default = 'ms-commerce-currency';
+			$sessionNamespace = $c['cfg']->app->sessionNamespace;
+
+			if(!(isset($c['cfg']->currency) && isset($c['cfg']->currency->cookieName)) || $default === $c['cfg']->currency->cookieName) {
+				return $sessionNamespace . '.' . $default;
 			}
 
 			return $c['cfg']->currency->cookieName;

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -1167,6 +1167,7 @@ class Services implements ServicesInterface
 	public function setupCurrencies($services)
 	{
 		$services['currency'] = function($c) {
+			de($c['currency.resolver']->getCurrency());
 			return $c['currency.resolver']->getCurrency();
 		};
 
@@ -1193,7 +1194,7 @@ class Services implements ServicesInterface
 			$sessionNamespace = $c['cfg']->app->sessionNamespace;
 
 			if(!(isset($c['cfg']->currency) && isset($c['cfg']->currency->cookieName)) || $default === $c['cfg']->currency->cookieName) {
-				return $sessionNamespace . '.' . $default;
+				return $sessionNamespace . '_' . $default;
 			}
 
 			return $c['cfg']->currency->cookieName;

--- a/src/Controller/Module/CurrencySelect.php
+++ b/src/Controller/Module/CurrencySelect.php
@@ -37,7 +37,7 @@ class CurrencySelect extends Controller
 
 			$this->get('http.cookies')
 				->add(new Cookie(
-						$this->get('cfg')->currency->cookieName, 
+						$this->get('currency.cookie.name'), 
 						$currency, 
 						date(time() + 9999999))); // dont expire anytime soon
 		}


### PR DESCRIPTION
#### What does this do?

Appends the session namespace to the currency cookie name, unless the cookie name isn't the default name. This prevents currency conflicts when working on multiple sites locally

#### How should this be manually tested?

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)