### PR TITLE
Don't load all products on ajax request

### DIFF
--- a/src/Controller/Product/Dashboard.php
+++ b/src/Controller/Product/Dashboard.php
@@ -4,6 +4,7 @@ namespace Message\Mothership\Commerce\Controller\Product;
 
 use Message\Cog\Controller\Controller;
 use Message\Mothership\ControlPanel\Event\Dashboard\DashboardEvent;
+use Message\Cog\HTTP\Response;
 
 class Dashboard extends Controller
 {
@@ -14,6 +15,12 @@ class Dashboard extends Controller
 
 	public function productTable()
 	{
+		// skip loading all the products if ajax request
+		if ($this->get('request')->server->has('HTTP_X_REQUESTED_WITH') && 
+			strtolower($this->get('request')->server->get('HTTP_X_REQUESTED_WITH')) == 'xmlhttprequest') {
+			return new Response();
+		}
+
 		$event = $this->get('event.dispatcher')->dispatch(
 			'dashboard.commerce.products',
 			new DashboardEvent


### PR DESCRIPTION
## What and why
Sites with a lot of products have a hard time loading in all the products on each ajax request. This should stop that from happening by not rendering the product table on ajax requests. The table is discarded by the javascript after the ajax call any way.

## How to test
Make sure the products admin is all working. Specifically that the table shows when it's supposed to, but doesn't get rendered in ajax calls.