### PR TITLE
Fix Order\Entity\Collection::remove() method

### DIFF
--- a/src/Order/Entity/Collection.php
+++ b/src/Order/Entity/Collection.php
@@ -77,9 +77,10 @@ class Collection implements CollectionInterface
 	 */
 	public function remove($entity)
 	{
+		$entity = ($entity instanceof EntityInterface) ? (int) $entity->id : (int) $entity;
+
 		foreach ($this->_items as $key => $item) {
-			if (($entity instanceof EntityInterface && $entity === $item)
-			 || $item->id == $entity) {
+			if ((int) $item->id === $entity) {
 				unset($this->_items[$key]);
 
 				return true;

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -133,13 +133,11 @@ class Order implements PayableInterface, Transaction\RecordInterface
 	/**
 	 * Get the items for this order.
 	 *
-	 * @deprecated Access the "items" property directly instead
+	 * @param  mixed $id                            Item ID if you want to get a
+	 *                                              specific item
 	 *
-	 * @param  mixed $filter                 Item ID if you want to get a
-	 *                                       specific item
-	 *
-	 * @return Entity\Collection|Entity\Item Collection of all items, or a
-	 *                                       specific item
+	 * @return Entity\Collection|Entity\Item\Item   Collection of all items, or a
+	 *                                              specific item
 	 */
 	public function getItems($id = null)
 	{


### PR DESCRIPTION
I was getting an error where PHP would attempt to cast the entity to an integer when doing the `$item->id == $entity` if statement. Weird behaviour from PHP as really it should just see that $entity is an object and return false, and I haven't been able to recreate the issue in test scripts so I'm not sure what's happening here.