### PR TITLE
Better validation on basket

### DIFF
--- a/src/Order/Event/UpdateFailedEvent.php
+++ b/src/Order/Event/UpdateFailedEvent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Message\Mothership\Commerce\Order\Event;
+
+class UpdateFailedEvent extends Event
+{
+
+}

--- a/src/Order/Events.php
+++ b/src/Order/Events.php
@@ -24,4 +24,6 @@ final class Events
 
 	const BUILD_ORDER_SIDEBAR   = 'commerce.order.sidebar.create';
 	const BUILD_ORDER_TABS      = 'commerce.order.tabs.create';
+
+	const UPDATE_FAILED         = 'commerce.order.update_failed';
 }

--- a/src/Order/Exception/UpdateFailedException.php
+++ b/src/Order/Exception/UpdateFailedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Message\Mothership\Commerce\Order\Exception;
+
+class UpdateFailedException extends \LogicException
+{
+
+}

--- a/src/Product/Tax/Exception/TaxRateNotFoundException.php
+++ b/src/Product/Tax/Exception/TaxRateNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Message\Mothership\Commerce\Product\Tax\Exception;
+
+/**
+ * Class TaxRateNotFoundException
+ * @package Message\Mothership\Commerce\Product\Tax\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Exception class to be thrown when a tax rate cannot be resolved due to it not being found
+ */
+class TaxRateNotFoundException extends \LogicException
+{
+
+}

--- a/src/Product/Tax/Resolver/TaxResolver.php
+++ b/src/Product/Tax/Resolver/TaxResolver.php
@@ -6,6 +6,7 @@ use Message\Mothership\Commerce\Product\Type\ProductTypeInterface;
 use Message\Mothership\Commerce\Address\Address;
 use Message\Mothership\Commerce\Product\Tax\Rate\TaxRateCollection;
 use Message\Mothership\Commerce\Product\Tax\Rate\TaxRate;
+use Message\Mothership\Commerce\Product\Tax\Exception;
 
 /**
  * {@inheritDoc}
@@ -45,7 +46,7 @@ class TaxResolver implements TaxResolverInterface
 		// validation
 		if (!isset($data->{$country})) {
 			if (!isset($data->{self::DEFAULT_COUNTRY})){
-				throw new \LogicException("Could not find given country tax configuration for country `$country` and no default set, make sure these are set in taxes config file");
+				throw new Exception\TaxRateNotFoundException("Could not find given country tax configuration for country `$country` and no default set, make sure these are set in taxes config file");
 			}
 
 			$country = self::DEFAULT_COUNTRY;
@@ -53,7 +54,7 @@ class TaxResolver implements TaxResolverInterface
 
 		if (!property_exists($data->{$country}, $region)) {
 			if (!property_exists($data->{$country}, self::DEFAULT_REGION)) {
-				throw new \LogicException("Could not find given region tax configuration for region `$address->stateID`, no default set. Make sure these are set in taxes config file");
+				throw new Exception\TaxRateNotFoundException("Could not find given region tax configuration for region `$address->stateID`, no default set. Make sure these are set in taxes config file");
 			}
 
 			$region = self::DEFAULT_REGION;


### PR DESCRIPTION
This PR:

+ Adds `TaxRateNotFoundException ` to the `Product\Tax` namespace
+ Adds `UpdateFailedEvent` to `Order\Event` namespace
+ Adds `UpdateFailedException` to `Order\Exception` namespace
+ The `TaxResolver` class now throws `TaxRateNotFoundException` when it cannot find a config setting for the tax rate
+ The `TotalsListener` catches `TaxRateNotFoundException` to revert to 'old' ways
+ The `TotalsListener` catches `UpdateFailedException` and dispatches an `UpdateFailedEvent` 