### PR TITLE
Feature/filter fix

### DIFF
--- a/src/Report/AbstractSales.php
+++ b/src/Report/AbstractSales.php
@@ -69,6 +69,23 @@ abstract class AbstractSales extends AbstractReport
 	}
 
 	/**
+	 * Get the filtered bas query
+	 * @return \Message\Cog\DB\QueryBuilder The base QueryBuilder
+	 */
+	protected function _getFilteredQuery()
+	{
+		$unions = $this->_dispatchEvent($this->getFilters())->getQueryBuilders();
+
+		$fromQuery = $this->_builderFactory->getQueryBuilder();
+
+		foreach($unions as $query) {
+			$fromQuery->unionAll($query);
+		}
+
+		return $fromQuery;
+	}
+
+	/**
 	 * Dispatch event.
 	 *
 	 * @param  FilterCollecion $filters  Any filters to be used in subqueries.

--- a/src/Report/AbstractSales.php
+++ b/src/Report/AbstractSales.php
@@ -67,6 +67,24 @@ abstract class AbstractSales extends AbstractReport
 			true
 		));
 	}
+	/**
+	 * Retrieves JSON representation of the data and columns.
+	 * Applies data to chart types set on report.
+	 *
+	 * @return Array  Returns all types of chart set on report with appropriate data.
+	 */
+	public function getCharts()
+	{
+		$data = $this->_dataTransform($this->_getQuery()->run(), "json");
+		$columns = $this->_parseColumns($this->getColumns());
+
+		foreach ($this->_charts as $chart) {
+			$chart->setColumns($columns);
+			$chart->setData($data);
+		}
+
+		return $this->_charts;
+	}
 
 	/**
 	 * Get the filtered bas query

--- a/src/Report/SalesByDay.php
+++ b/src/Report/SalesByDay.php
@@ -87,13 +87,7 @@ class SalesByDay extends AbstractSales
 	 */
 	protected function _getQuery()
 	{
-		$unions = $this->_dispatchEvent($this->getFilters())->getQueryBuilders();
-
-		$fromQuery = $this->_builderFactory->getQueryBuilder();
-
-		foreach($unions as $query) {
-			$fromQuery->unionAll($query);
-		}
+		$fromQuery = $this->_getFilteredQuery();
 
 		$queryBuilder = $this->_builderFactory->getQueryBuilder();
 		$queryBuilder

--- a/src/Report/SalesByDay.php
+++ b/src/Report/SalesByDay.php
@@ -42,25 +42,6 @@ class SalesByDay extends AbstractSales
 	}
 
 	/**
-	 * Retrieves JSON representation of the data and columns.
-	 * Applies data to chart types set on report.
-	 *
-	 * @return array  Returns all types of chart set on report with appropriate data.
-	 */
-	public function getCharts()
-	{
-		$data = $this->_dataTransform($this->_getQuery()->run(), "json");
-		$columns = $this->_parseColumns($this->getColumns());
-
-		foreach ($this->_charts as $chart) {
-			$chart->setColumns($columns);
-			$chart->setData($data);
-		}
-
-		return $this->_charts;
-	}
-
-	/**
 	 * Set columns for use in reports.
 	 *
 	 * @return array  Returns array of columns as keys with format for Google Charts as the value.

--- a/src/Report/SalesByItem.php
+++ b/src/Report/SalesByItem.php
@@ -91,13 +91,7 @@ class SalesByItem extends AbstractSales
 	 */
 	protected function _getQuery()
 	{
-		$unions = $this->_dispatchEvent($this->getFilters())->getQueryBuilders();
-
-		$fromQuery = $this->_builderFactory->getQueryBuilder();
-
-		foreach($unions as $query) {
-			$fromQuery->unionAll($query);
-		}
+		$fromQuery = $this->_getFilteredQuery();
 
 		$queryBuilder = $this->_builderFactory->getQueryBuilder();
 		$queryBuilder

--- a/src/Report/SalesByItem.php
+++ b/src/Report/SalesByItem.php
@@ -40,25 +40,6 @@ class SalesByItem extends AbstractSales
 	}
 
 	/**
-	 * Retrieves JSON representation of the data and columns.
-	 * Applies data to chart types set on report.
-	 *
-	 * @return array  Returns all types of chart set on report with appropriate data.
-	 */
-	public function getCharts()
-	{
-		$data = $this->_dataTransform($this->_getQuery()->run(), "json");
-		$columns = $this->_parseColumns($this->getColumns());
-
-		foreach ($this->_charts as $chart) {
-			$chart->setColumns($columns);
-			$chart->setData($data);
-		}
-
-		return $this->_charts;
-	}
-
-	/**
 	 * Set columns for use in reports.
 	 *
 	 * @return array  Returns array of columns as keys with format for Google Charts as the value.

--- a/src/Report/SalesByLocation.php
+++ b/src/Report/SalesByLocation.php
@@ -40,25 +40,6 @@ class SalesByLocation extends AbstractSales
 	}
 
 	/**
-	 * Retrieves JSON representation of the data and columns.
-	 * Applies data to chart types set on report.
-	 *
-	 * @return Array  Returns all types of chart set on report with appropriate data.
-	 */
-	public function getCharts()
-	{
-		$data = $this->_dataTransform($this->_getQuery()->run(), "json");
-		$columns = $this->_parseColumns($this->getColumns());
-
-		foreach ($this->_charts as $chart) {
-			$chart->setColumns($columns);
-			$chart->setData($data);
-		}
-
-		return $this->_charts;
-	}
-
-	/**
 	 * Set columns for use in reports.
 	 *
 	 * @return array  Returns array of columns as keys with format for Google Charts as the value.

--- a/src/Report/SalesByLocation.php
+++ b/src/Report/SalesByLocation.php
@@ -85,13 +85,7 @@ class SalesByLocation extends AbstractSales
 	 */
 	protected function _getQuery()
 	{
-		$unions = $this->_dispatchEvent()->getQueryBuilders();
-
-		$fromQuery = $this->_builderFactory->getQueryBuilder();
-
-		foreach($unions as $query) {
-			$fromQuery->unionAll($query);
-		}
+		$fromQuery = $this->_getFilteredQuery();
 
 		$queryBuilder = $this->_builderFactory->getQueryBuilder();
 		$queryBuilder

--- a/src/Report/SalesByMonth.php
+++ b/src/Report/SalesByMonth.php
@@ -40,25 +40,6 @@ class SalesByMonth extends AbstractSales
 	}
 
 	/**
-	 * Retrieves JSON representation of the data and columns.
-	 * Applies data to chart types set on report.
-	 *
-	 * @return Array  Returns all types of chart set on report with appropriate data.
-	 */
-	public function getCharts()
-	{
-		$data = $this->_dataTransform($this->_getQuery()->run(), "json");
-		$columns = $this->_parseColumns($this->getColumns());
-
-		foreach ($this->_charts as $chart) {
-			$chart->setColumns($columns);
-			$chart->setData($data);
-		}
-
-		return $this->_charts;
-	}
-
-	/**
 	 * Set columns for use in reports.
 	 *
 	 * @return array  Returns array of columns as keys with format for Google Charts as the value.

--- a/src/Report/SalesByMonth.php
+++ b/src/Report/SalesByMonth.php
@@ -85,12 +85,7 @@ class SalesByMonth extends AbstractSales
 	 */
 	protected function _getQuery()
 	{
-		$unions = $this->_dispatchEvent($this->getFilters())->getQueryBuilders();
-
-		$fromQuery = $this->_builderFactory->getQueryBuilder();
-		foreach($unions as $query) {
-			$fromQuery->unionAll($query);
-		}
+		$fromQuery = $this->_getFilteredQuery();
 
 		$queryBuilder = $this->_builderFactory->getQueryBuilder();
 		$queryBuilder

--- a/src/Report/SalesByOrder.php
+++ b/src/Report/SalesByOrder.php
@@ -40,25 +40,6 @@ class SalesByOrder extends AbstractSales
 	}
 
 	/**
-	 * Retrieves JSON representation of the data and columns.
-	 * Applies data to chart types set on report.
-	 *
-	 * @return Array  Returns all types of chart set on report with appropriate data.
-	 */
-	public function getCharts()
-	{
-		$data = $this->_dataTransform($this->_getQuery()->run(), "json");
-		$columns = $this->_parseColumns($this->getColumns());
-
-		foreach ($this->_charts as $chart) {
-			$chart->setColumns($columns);
-			$chart->setData($data);
-		}
-
-		return $this->_charts;
-	}
-
-	/**
 	 * Set columns for use in reports.
 	 *
 	 * @return array  Returns array of columns as keys with format for Google Charts as the value.

--- a/src/Report/SalesByOrder.php
+++ b/src/Report/SalesByOrder.php
@@ -89,12 +89,7 @@ class SalesByOrder extends AbstractSales
 	 */
 	protected function _getQuery()
 	{
-		$unions = $this->_dispatchEvent($this->getFilters())->getQueryBuilders();
-
-		$fromQuery = $this->_builderFactory->getQueryBuilder();
-		foreach($unions as $query) {
-			$fromQuery->unionAll($query);
-		}
+		$fromQuery = $this->_getFilteredQuery();
 
 		$queryBuilder = $this->_builderFactory->getQueryBuilder();
 		$queryBuilder

--- a/src/Report/SalesByProduct.php
+++ b/src/Report/SalesByProduct.php
@@ -87,12 +87,7 @@ class SalesByProduct extends AbstractSales
 	 */
 	protected function _getQuery()
 	{
-		$unions = $this->_dispatchEvent($this->getFilters())->getQueryBuilders();
-
-		$fromQuery = $this->_builderFactory->getQueryBuilder();
-		foreach($unions as $query) {
-			$fromQuery->unionAll($query);
-		}
+		$fromQuery = $this->_getFilteredQuery();
 
 		$queryBuilder = $this->_builderFactory->getQueryBuilder();
 		$queryBuilder

--- a/src/Report/SalesByProduct.php
+++ b/src/Report/SalesByProduct.php
@@ -40,25 +40,6 @@ class SalesByProduct extends AbstractSales
 	}
 
 	/**
-	 * Retrieves JSON representation of the data and columns.
-	 * Applies data to chart types set on report.
-	 *
-	 * @return Array  Returns all types of chart set on report with appropriate data.
-	 */
-	public function getCharts()
-	{
-		$data = $this->_dataTransform($this->_getQuery()->run(), "json");
-		$columns = $this->_parseColumns($this->getColumns());
-
-		foreach ($this->_charts as $chart) {
-			$chart->setColumns($columns);
-			$chart->setData($data);
-		}
-
-		return $this->_charts;
-	}
-
-	/**
 	 * Set columns for use in reports.
 	 *
 	 * @return array  Returns array of columns as keys with format for Google Charts as the value.

--- a/src/Report/SalesByUser.php
+++ b/src/Report/SalesByUser.php
@@ -41,25 +41,6 @@ class SalesByUser extends AbstractSales
 	}
 
 	/**
-	 * Retrieves JSON representation of the data and columns.
-	 * Applies data to chart types set on report.
-	 *
-	 * @return Array  Returns all types of chart set on report with appropriate data.
-	 */
-	public function getCharts()
-	{
-		$data = $this->_dataTransform($this->_getQuery()->run(), "json");
-		$columns = $this->_parseColumns($this->getColumns());
-
-		foreach ($this->_charts as $chart) {
-			$chart->setColumns($columns);
-			$chart->setData($data);
-		}
-
-		return $this->_charts;
-	}
-
-	/**
 	 * Set columns for use in reports.
 	 *
 	 * @return array  Returns array of columns as keys with format for Google Charts as the value.

--- a/src/Report/SalesByUser.php
+++ b/src/Report/SalesByUser.php
@@ -87,12 +87,7 @@ class SalesByUser extends AbstractSales
 	 */
 	protected function _getQuery()
 	{
-		$unions = $this->_dispatchEvent($this->getFilters())->getQueryBuilders();
-
-		$fromQuery = $this->_builderFactory->getQueryBuilder();
-		foreach($unions as $query) {
-			$fromQuery->unionAll($query);
-		}
+		$fromQuery = $this->_getFilteredQuery();
 
 		$queryBuilder = $this->_builderFactory->getQueryBuilder();
 		$queryBuilder


### PR DESCRIPTION
### What is this?

This fixes the filtering on sales by location. The line
`$unions = $this->_dispatchEvent($this->getFilters())->getQueryBuilders();`
was
`$unions = $this->_dispatchEvent()->getQueryBuilders();`
in the SalesByLocation report.

It also abstracts some shared functionality to the AbstractSales class.

### Testing

Test filtering on the SalesByLocation report. Also test all of the other sales report are not broken by this change.