### PR TITLE
Add methods for getting option prices

### DIFF
--- a/src/Product/Exception/PriceNotFoundException.php
+++ b/src/Product/Exception/PriceNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Message\Mothership\Commerce\Product\Exception;
+
+/**
+ * Class PriceNotFoundException
+ * @package Message\Mothership\Commerce\Product\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
+class PriceNotFoundException extends \LogicException
+{
+
+}

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -293,19 +293,18 @@ class Product implements Price\PricedInterface
 	{
 		$currencyID = $currencyID ?: $this->_defaultCurrency;
 
-		$prices = [$this->getPrice($type, $currencyID)];
+		$prices = [];
 
 		foreach ($this->getVisibleUnits() as $unit) {
 			$hasAllOptions = true;
 			$unitPrices = [];
 
 			foreach ($options as $name => $value) {
-				if (!$unit->hasOption($name)) {
+				if ($unit->hasOption($name) && $unit->getOption($name) === $value) {
+					$unitPrices[] = $unit->getPrice($type, $currencyID);
+				} else {
 					$hasAllOptions = false;
 					break;
-				}
-				if ($unit->getOption($name) === $value) {
-					$unitPrices[] = $unit->getPrice($type, $currencyID);
 				}
 			}
 			if ($hasAllOptions) {

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -226,10 +226,12 @@ class Product implements Price\PricedInterface
 	/**
 	 * Get the highest or lowest price for a specific option
 	 *
-	 * @param array $options             The options to return the price for
-	 * @param string $type               The type of price, defaults to 'retail'
-	 * @param null|string $currencyID    The currency ID, will be the default currency if set to null
-	 * @param bool $returnHighest        Set as true to return the highest price, and false to return the lowest price
+	 * @param array $options                        The options to return the price for
+	 * @param string $type                          The type of price, defaults to 'retail'
+	 * @param null|string $currencyID               The currency ID, will be the default currency if set to null
+	 * @param bool $returnHighest                   Set as true to return the highest price, and false to return the
+	 *                                              lowest price
+	 * @throws Exception\PriceNotFoundException     Throws exception if no price can be found
 	 *
 	 * @return string
 	 */
@@ -238,7 +240,14 @@ class Product implements Price\PricedInterface
 		$prices = $this->getOptionPrices($options, $type, $currencyID);
 		sort($prices);
 
-		return ($returnHighest) ? array_pop($prices) : array_shift($prices);
+		$price = ($returnHighest) ? array_pop($prices) : array_shift($prices);
+
+		if (false === $price) {
+			$optionsString = implode(', ', $options);
+			throw new Exception\PriceNotFoundException('Could not find price for product ' . $this->id . ', with options ' . $optionsString . ' and a currency ID of ' . $currencyID);
+		}
+
+		return $price;
 	}
 
 	/**
@@ -257,13 +266,28 @@ class Product implements Price\PricedInterface
 	}
 
 	/**
+	 * Get the highest price for a specific option, acts as a shorthand alias for `getOptionPrice()` with $returnHighest
+	 * set to true
+	 *
+	 * @param array $options                The options to return the price for
+	 * @param string $type                  The type of price, defaults to 'retail'
+	 * @param null | string $currencyID     The currency ID, will be the default currency if set to null
+	 *
+	 * @return string
+	 */
+	public function getOptionPriceTo(array $options, $type = 'retail', $currencyID = null)
+	{
+		return $this->getOptionPrice($options, $type, $currencyID, true);
+	}
+
+	/**
 	 * Get an array of all unique prices for a specific option
 	 *
 	 * @param array $options             The options to return the price for
 	 * @param string $type               The type of price, defaults to 'retail'
 	 * @param null|string $currencyID    The currency ID, will be the default currency if set to null
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function getOptionPrices(array $options, $type = 'retail', $currencyID = null)
 	{

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -208,17 +208,78 @@ class Product implements Price\PricedInterface
 		$currencyID = $currencyID ?: $this->_defaultCurrency;
 
 		$basePrice = $this->getPrice($type, $currencyID);
-		$prices    = array();
+		$prices    = [];
 
 		foreach ($this->getVisibleUnits() as $unit) {
 			if ($unit->getPrice($type, $currencyID) < $basePrice) {
-				$prices[$unit->getPrice($type, $currencyID)] = $unit->getPrice($type, $currencyID);
+				$prices[] = $unit->getPrice($type, $currencyID);
 			}
 		}
+
 		// Sort the array with lowest value at the top
-		ksort($prices);
+		sort($prices);
+
 		// get the lowest value
 		return $prices ? array_shift($prices) : $basePrice;
+	}
+
+	/**
+	 * Get the highest or lowest price for a specific option
+	 *
+	 * @param array $options             The options to return the price for
+	 * @param string $type               The type of price, defaults to 'retail'
+	 * @param null|string $currencyID    The currency ID, will be the default currency if set to null
+	 * @param bool $returnHighest        Set as true to return the highest price, and false to return the lowest price
+	 *
+	 * @return string
+	 */
+	public function getOptionPrice(array $options, $type = 'retail', $currencyID = null, $returnHighest = true)
+	{
+		$prices = $this->getOptionPrices($options, $type, $currencyID);
+		sort($prices);
+
+		return ($returnHighest) ? array_pop($prices) : array_shift($prices);
+	}
+
+	/**
+	 * Get the lowest price for a specific option, acts as a shorthand alias for `getOptionPrice()` with $returnHighest
+	 * set to false
+	 *
+	 * @param array $options             The options to return the price for
+	 * @param string $type               The type of price, defaults to 'retail'
+	 * @param null|string $currencyID    The currency ID, will be the default currency if set to null
+	 *
+	 * @return string
+	 */
+	public function getOptionPriceFrom(array $options, $type = 'retail', $currencyID = null)
+	{
+		return $this->getOptionPrice($options, $type, $currencyID, false);
+	}
+
+	/**
+	 * Get an array of all unique prices for a specific option
+	 *
+	 * @param array $options             The options to return the price for
+	 * @param string $type               The type of price, defaults to 'retail'
+	 * @param null|string $currencyID    The currency ID, will be the default currency if set to null
+	 *
+	 * @return string
+	 */
+	public function getOptionPrices(array $options, $type = 'retail', $currencyID = null)
+	{
+		$currencyID = $currencyID ?: $this->_defaultCurrency;
+
+		$prices = [$this->getPrice($type, $currencyID)];
+
+		foreach ($this->getVisibleUnits() as $unit) {
+			foreach ($options as $name => $value) {
+				if ($unit->getOption($name) === $value) {
+					$prices[] = $unit->getPrice($type, $currencyID);
+				}
+			}
+		}
+
+		return array_unique($prices);
 	}
 
 	/**

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -281,7 +281,7 @@ class Product implements Price\PricedInterface
 	}
 
 	/**
-	 * Get an array of all unique prices for a specific option
+	 * Get an array of all unique prices for a specific set of options
 	 *
 	 * @param array $options             The options to return the price for
 	 * @param string $type               The type of price, defaults to 'retail'
@@ -296,10 +296,20 @@ class Product implements Price\PricedInterface
 		$prices = [$this->getPrice($type, $currencyID)];
 
 		foreach ($this->getVisibleUnits() as $unit) {
+			$hasAllOptions = true;
+			$unitPrices = [];
+
 			foreach ($options as $name => $value) {
-				if ($unit->getOption($name) === $value) {
-					$prices[] = $unit->getPrice($type, $currencyID);
+				if (!$unit->hasOption($name)) {
+					$hasAllOptions = false;
+					break;
 				}
+				if ($unit->getOptions($name) === $value) {
+					$unitPrices[] = $unit->getPrice($type, $currencyID);
+				}
+			}
+			if ($hasAllOptions) {
+				$prices = $prices + $unitPrices;
 			}
 		}
 

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -233,7 +233,7 @@ class Product implements Price\PricedInterface
 	 *                                              lowest price
 	 * @throws Exception\PriceNotFoundException     Throws exception if no price can be found
 	 *
-	 * @return string
+	 * @return float
 	 */
 	public function getOptionPrice(array $options, $type = 'retail', $currencyID = null, $returnHighest = true)
 	{
@@ -258,7 +258,7 @@ class Product implements Price\PricedInterface
 	 * @param string $type               The type of price, defaults to 'retail'
 	 * @param null|string $currencyID    The currency ID, will be the default currency if set to null
 	 *
-	 * @return string
+	 * @return float
 	 */
 	public function getOptionPriceFrom(array $options, $type = 'retail', $currencyID = null)
 	{
@@ -273,7 +273,7 @@ class Product implements Price\PricedInterface
 	 * @param string $type                  The type of price, defaults to 'retail'
 	 * @param null | string $currencyID     The currency ID, will be the default currency if set to null
 	 *
-	 * @return string
+	 * @return float
 	 */
 	public function getOptionPriceTo(array $options, $type = 'retail', $currencyID = null)
 	{
@@ -304,12 +304,12 @@ class Product implements Price\PricedInterface
 					$hasAllOptions = false;
 					break;
 				}
-				if ($unit->getOptions($name) === $value) {
+				if ($unit->getOption($name) === $value) {
 					$unitPrices[] = $unit->getPrice($type, $currencyID);
 				}
 			}
 			if ($hasAllOptions) {
-				$prices = $prices + $unitPrices;
+				$prices = array_merge($prices, $unitPrices);
 			}
 		}
 


### PR DESCRIPTION
This PR adds the following methods allowing the prices for specific options on a Product to be accessed:

+ getOptionPrice() - get either the highest or lowest price for specific option on a product, defaults to highest
+ getOptionPriceFrom() - get the lowest price for specific options on a product
+ getOptionPrices() - get all unique prices assigned to specific options on a product