### PR TITLE
Product loader caching

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -477,7 +477,7 @@ class Services implements ServicesInterface
 			);
 		});
 
-		$services['product.create'] = function($c) {
+		$services['product.create'] = $services->factory(function($c) {
 			$create = new Commerce\Product\Create($c['db.query'],
 				$c['locale'],
 				$c['user.current'],
@@ -488,7 +488,7 @@ class Services implements ServicesInterface
 			$create->setDefaultTaxStrategy($c['product.tax.strategy']);
 
 			return $create;
-		};
+		});
 
 		$services['product.form.data_transform'] = $services->factory(function($c) {
 			return new Commerce\Product\Form\DataTransform\ProductTransform(

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -448,7 +448,9 @@ class Services implements ServicesInterface
 			]);
 		});
 
-		$services['product.loader'] = function($c) {
+		// Product loader should not be a singleton as 'includeDeleted' needs to be reset to false on every
+		// instanciation
+		$services['product.loader'] = $services->factory(function($c) {
 			return new Commerce\Product\Loader(
 				$c['db.query'],
 				$c['locale'],
@@ -461,7 +463,7 @@ class Services implements ServicesInterface
 				$c['product.tax.strategy'],
 				$c['product.cache']
 			);
-		};
+		});
 
 		$services['product.cache'] = function($c) {
 			return new Commerce\Product\Collection;
@@ -504,7 +506,7 @@ class Services implements ServicesInterface
 		});
 
 		$services['product.edit'] = $services->factory(function($c) {
-			return new Commerce\Product\Edit($c['db.transaction'], $c['locale'], $c['user.current']);
+			return new Commerce\Product\Edit($c['db.transaction'], $c['locale'], $c['user.current'], $c['event.dispatcher']);
 		});
 
 		$services['product.delete'] = $services->factory(function($c) {

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -448,7 +448,7 @@ class Services implements ServicesInterface
 			]);
 		});
 
-		$services['product.loader'] = $services->factory(function($c) {
+		$services['product.loader'] = function($c) {
 			return new Commerce\Product\Loader(
 				$c['db.query'],
 				$c['locale'],
@@ -458,9 +458,14 @@ class Services implements ServicesInterface
 				$c['product.entity_loaders'],
 				$c['product.price.types'],
 				$c['currency'],
-				$c['product.tax.strategy']
+				$c['product.tax.strategy'],
+				$c['product.cache']
 			);
-		});
+		};
+
+		$services['product.cache'] = function($c) {
+			return new Commerce\Product\Collection;
+		};
 
 		$services['product.searcher'] = $services->factory(function($c) {
 			return new Commerce\Product\Searcher(
@@ -470,7 +475,7 @@ class Services implements ServicesInterface
 			);
 		});
 
-		$services['product.create'] = $services->factory(function($c) {
+		$services['product.create'] = function($c) {
 			$create = new Commerce\Product\Create($c['db.query'],
 				$c['locale'],
 				$c['user.current'],
@@ -481,7 +486,7 @@ class Services implements ServicesInterface
 			$create->setDefaultTaxStrategy($c['product.tax.strategy']);
 
 			return $create;
-		});
+		};
 
 		$services['product.form.data_transform'] = $services->factory(function($c) {
 			return new Commerce\Product\Form\DataTransform\ProductTransform(

--- a/src/EventListener.php
+++ b/src/EventListener.php
@@ -330,6 +330,11 @@ class EventListener extends BaseListener implements SubscriberInterface
 		}
 	}
 
+	/**
+	 * Remove products from the cache if they have been edited
+	 *
+	 * @param Product\Event $event
+	 */
 	public function removeProductFromCache(Product\Event $event)
 	{
 		if ($this->get('product.cache')->exists($event->getProduct()->id)) {

--- a/src/EventListener.php
+++ b/src/EventListener.php
@@ -52,11 +52,6 @@ class EventListener extends BaseListener implements SubscriberInterface
 			OrderEvents::DISPATCH_SHIPPED => array(
 				array('recordOrderOut'),
 			),
-			// OrderEvents::DELETE_END => array(
-			// 	array('recordOrderDeleted'),
-			// 	array('recordSalesNetDeleted'),
-			// 	array('recordProductsSalesDeleted'),
-			// ),
 			DashboardEvent::DASHBOARD_INDEX => array(
 				array('buildDashboardProducts'),
 				array('buildDashboardOrders'),
@@ -78,6 +73,9 @@ class EventListener extends BaseListener implements SubscriberInterface
 			],
 			Events::TRANSACTIONS_REPORT => [
 				'buildTransactionReport'
+			],
+			Product\Events::PRODUCT_EDIT => [
+				'removeProductFromCache'
 			],
 		);
 	}
@@ -235,7 +233,7 @@ class EventListener extends BaseListener implements SubscriberInterface
 	/**
 	 * Decrement the orders.in stat.
 	 *
-	 * @param  EventEvent $event
+	 * @param  Event\Event $event
 	 */
 	public function recordOrderDeleted(Event\Event $event)
 	{
@@ -329,6 +327,13 @@ class EventListener extends BaseListener implements SubscriberInterface
 				$query->setFilters($event->getFilters());
 			}
 			$event->addQueryBuilder($query->getQueryBuilder());
+		}
+	}
+
+	public function removeProductFromCache(Product\Event $event)
+	{
+		if ($this->get('product.cache')->exists($event->getProduct()->id)) {
+			$this->get('product.cache')->remove($event->getProduct()->id);
 		}
 	}
 

--- a/src/Product/Edit.php
+++ b/src/Product/Edit.php
@@ -2,15 +2,12 @@
 
 namespace Message\Mothership\Commerce\Product;
 
-use Message\Mothership\Commerce\Product\Product;
-use Message\Cog\ValueObject\DateTimeImmutable;
-use Message\Cog\Localisation\Locale;
-
 use Message\User\UserInterface;
 
+use Message\Cog\Localisation\Locale;
+use Message\Cog\Event\Dispatcher;
 use Message\Cog\DB\Transaction;
 use Message\Cog\DB\TransactionalInterface;
-use Message\Cog\DB\Result;
 
 /**
  * Class for updating the attributes of a given Product object to the DB
@@ -37,13 +34,23 @@ class Edit implements TransactionalInterface
 	 */
 	protected $_product;
 
+	/**
+	 * @var bool
+	 */
 	protected $_transOverridden = false;
 
-	public function __construct(Transaction $trans, Locale $locale, UserInterface $user)
+	/**
+	 * @var Dispatcher
+	 */
+	private $_dispatcher;
+
+
+	public function __construct(Transaction $trans, Locale $locale, UserInterface $user, Dispatcher $dispatcher)
 	{
-		$this->_trans  = $trans;
-		$this->_user   = $user;
-		$this->_locale = $locale;
+		$this->_trans      = $trans;
+		$this->_user       = $user;
+		$this->_locale     = $locale;
+		$this->_dispatcher = $dispatcher;
 	}
 
 	/**
@@ -64,6 +71,11 @@ class Edit implements TransactionalInterface
 		if (!$this->_transOverridden) {
 			$this->_trans->commit();
 		}
+
+		$this->_dispatcher->dispatch(
+			Events::PRODUCT_EDIT,
+			new Event($product)
+		);
 
 		return $product;
 	}

--- a/src/Product/Event.php
+++ b/src/Product/Event.php
@@ -4,8 +4,17 @@ namespace Message\Mothership\Commerce\Product;
 
 use Message\Cog\Event\Event as BaseEvent;
 
+/**
+ * Class Event
+ * @package Message\Mothership\Commerce\Product
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
 class Event extends BaseEvent
 {
+	/**
+	 * @var Product
+	 */
 	private $_product;
 
 	public function __construct(Product $product)
@@ -13,11 +22,17 @@ class Event extends BaseEvent
 		$this->setProduct($product);
 	}
 
+	/**
+	 * @param Product $product
+	 */
 	public function setProduct(Product $product)
 	{
 		$this->_product = $product;
 	}
 
+	/**
+	 * @return Product
+	 */
 	public function getProduct()
 	{
 		return $this->_product;

--- a/src/Product/Event.php
+++ b/src/Product/Event.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Message\Mothership\Commerce\Product;
+
+use Message\Cog\Event\Event as BaseEvent;
+
+class Event extends BaseEvent
+{
+	private $_product;
+
+	public function __construct(Product $product)
+	{
+		$this->setProduct($product);
+	}
+
+	public function setProduct(Product $product)
+	{
+		$this->_product = $product;
+	}
+
+	public function getProduct()
+	{
+		return $this->_product;
+	}
+}

--- a/src/Product/Events.php
+++ b/src/Product/Events.php
@@ -5,6 +5,7 @@ namespace Message\Mothership\Commerce\Product;
 class Events
 {
 	const STOCK_MOVEMENT          = 'commerce.product.stock.movement';
+	const PRODUCT_EDIT            = 'commerce.product.edit';
 	const PRODUCT_UPLOAD_CREATE   = 'commerce.product_upload.product_create';
 	const UNIT_UPLOAD_CREATE      = 'commerce.product_upload.unit_create';
 	const PRODUCT_UPLOAD_COMPLETE = 'commerce.product_upload.complete';

--- a/src/Product/Loader.php
+++ b/src/Product/Loader.php
@@ -331,6 +331,7 @@ class Loader
 			foreach ($productIDs as $key => $id) {
 				if ($this->_productCache->exists($id)) {
 					$cachedProduct = $this->_productCache->get($id);
+					// Only load deleted products from the cache if `_includeDeleted` is set to true
 					if ($this->_includeDeleted || !$cachedProduct->authorship->isDeleted()) {
 						$cachedProducts[] = $cachedProduct;
 						unset($productIDs[$key]);

--- a/src/Product/Loader.php
+++ b/src/Product/Loader.php
@@ -325,6 +325,8 @@ class Loader
 
 		$cachedProducts = [];
 
+		// Load products from cache if limit is not set. If limit is set this complicates the following query so
+		// this step is skipped.
 		if (null === $limit) {
 			foreach ($productIDs as $key => $id) {
 				if ($this->_productCache->exists($id)) {
@@ -339,6 +341,7 @@ class Loader
 			$this->_checkLimit($limit);
 		}
 
+		// If there are no uncached products remaining, return the cached product/s
 		if (count($productIDs) <= 0) {
 			return $this->_returnArray ? $cachedProducts : array_shift($cachedProducts);
 		}
@@ -432,9 +435,11 @@ class Loader
 
 			$this->_loadType($products[$key], $data->type);
 
+			// Add product to cache
 			$this->_productCache->add($products[$key]);
 		}
 
+		// Merge cached products and main products array
 		$products = array_merge($products, $cachedProducts);
 
 		return count($products) == 1 && !$this->_returnArray ? array_shift($products) : $products;

--- a/src/Product/Loader.php
+++ b/src/Product/Loader.php
@@ -14,16 +14,55 @@ use Message\Mothership\Commerce\Product\Tax\Strategy\TaxStrategyInterface;
 
 class Loader
 {
+	/**
+	 * @var Query
+	 */
 	protected $_query;
+
+	/**
+	 * @var Locale
+	 */
 	protected $_locale;
+
+	/**
+	 * @var bool
+	 */
 	protected $_includeDeleted = false;
 
+	/**
+	 * @var bool
+	 */
 	protected $_returnArray;
+
+	/**
+	 * @var Type\Collection
+	 */
 	protected $_productTypes;
+
+	/**
+	 * @var Type\DetailLoader
+	 */
 	protected $_detailLoader;
+
+	/**
+	 * @var EntityLoaderCollection
+	 */
 	protected $_entityLoaders;
+
+	/**
+	 * @var TaxStrategyInterface
+	 */
 	protected $_taxStrategy;
+
+	/**
+	 * @var array
+	 */
 	protected $_priceTypes;
+
+	/**
+	 * @var Collection
+	 */
+	private $_productCache;
 
 	public function __construct(
 		Query $query,
@@ -34,17 +73,19 @@ class Loader
 		EntityLoaderCollection $entityLoaders,
 		$priceTypes = array(),
 		$defaultCurrency,
-		TaxStrategyInterface $taxStrategy
+		TaxStrategyInterface $taxStrategy,
+		Collection $productCache
 	) {
-		$this->_query         = $query;
-		$this->_locale        = $locale;
-		$this->_productTypes  = $productTypes;
-		$this->_detailLoader  = $detailLoader;
-		$this->_priceTypes    = $priceTypes;
-		$this->_fileLoader    = $fileLoader;
-		$this->_entityLoaders = $entityLoaders;
+		$this->_query           = $query;
+		$this->_locale          = $locale;
+		$this->_productTypes    = $productTypes;
+		$this->_detailLoader    = $detailLoader;
+		$this->_priceTypes      = $priceTypes;
+		$this->_fileLoader      = $fileLoader;
+		$this->_entityLoaders   = $entityLoaders;
 		$this->_defaultCurrency = $defaultCurrency;
-		$this->_taxStrategy    = $taxStrategy;
+		$this->_taxStrategy     = $taxStrategy;
+		$this->_productCache    = $productCache;
 	}
 
 	public function getEntityLoader($entityName)
@@ -278,15 +319,29 @@ class Loader
 			$productIDs = (array) $productIDs;
 		}
 
-		if (!$productIDs) {
-			return $this->_returnArray ? array() : false;
-		}
-
 		if (0 === $this->_entityLoaders->count()) {
 			throw new \LogicException('Cannot load products when entity loaders are not set.');
 		}
 
-		$this->_checkLimit($limit);
+		$cachedProducts = [];
+
+		if (null === $limit) {
+			foreach ($productIDs as $key => $id) {
+				if ($this->_productCache->exists($id)) {
+					$cachedProduct = $this->_productCache->get($id);
+					if ($this->_includeDeleted || !$cachedProduct->authorship->isDeleted()) {
+						$cachedProducts[] = $cachedProduct;
+						unset($productIDs[$key]);
+					}
+				}
+			}
+		} else {
+			$this->_checkLimit($limit);
+		}
+
+		if (count($productIDs) <= 0) {
+			return $this->_returnArray ? $cachedProducts : array_shift($cachedProducts);
+		}
 
 		$result = $this->_query->run(
 			'SELECT
@@ -376,7 +431,11 @@ class Loader
 			}
 
 			$this->_loadType($products[$key], $data->type);
+
+			$this->_productCache->add($products[$key]);
 		}
+
+		$products = array_merge($products, $cachedProducts);
 
 		return count($products) == 1 && !$this->_returnArray ? array_shift($products) : $products;
 	}

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -52,6 +52,8 @@ class Product implements Price\PricedInterface
 	protected $_entities = [];
 	protected $_defaultCurrency;
 
+	private $_optionPrices = [];
+
 	/**
 	 * Initiate the object and set some basic properties up
 	 *
@@ -291,6 +293,12 @@ class Product implements Price\PricedInterface
 	 */
 	public function getOptionPrices(array $options, $type = 'retail', $currencyID = null)
 	{
+		$key = serialize($options);
+
+		if (array_key_exists($key, $this->_optionPrices)) {
+			return $this->_optionPrices[$key];
+		}
+
 		$currencyID = $currencyID ?: $this->_defaultCurrency;
 
 		$prices = [];
@@ -312,7 +320,11 @@ class Product implements Price\PricedInterface
 			}
 		}
 
-		return array_unique($prices);
+		$prices = array_unique($prices);
+
+		$this->_optionPrices[$key] = $prices;
+
+		return $prices;
 	}
 
 	/**


### PR DESCRIPTION
This PR implements caching on the product loader. Product listing pages were loading the same products multiple times, which in turn meant that the product units were being unnecessarily loaded multiple times, effectively undoing the benefit of the lazy loading.

This PR adds a singleton instance of Product\Collection to the loader which will store any products that are loaded. If the product is requested again, the loader will check the cache before loading from the database. If the product is edited, an event is fired to remove it from the cache.

Also, when loading option prices, the loaded prices will be stored in memory for subsequent requests.