### PR TITLE
Images on product upload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"mothership-ec/cog"                        : "~4.0",
 		"mothership-ec/cog-mothership-user"        : "~4.0",
 		"mothership-ec/cog-imageresize"            : "~2.0",
-		"mothership-ec/cog-mothership-file-manager": "~3.0",
+		"mothership-ec/cog-mothership-file-manager": "dev-feature/add-load-by-filename-method as 3.1.0",
 		"mothership-ec/cog-mothership-cp"          : "~3.2",
         "mothership-ec/cog-mothership-reports"     : "~2.0",
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"mothership-ec/cog"                        : "~4.0",
 		"mothership-ec/cog-mothership-user"        : "~4.0",
 		"mothership-ec/cog-imageresize"            : "~2.0",
-		"mothership-ec/cog-mothership-file-manager": "dev-feature/add-load-by-filename-method as 3.1.0",
+		"mothership-ec/cog-mothership-file-manager": "~3.0",
 		"mothership-ec/cog-mothership-cp"          : "~3.2",
         "mothership-ec/cog-mothership-reports"     : "~2.0",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "669579c1d72273d33641da497c6ab9f7",
+    "hash": "afd9bf44cc0ca10cb3ad2b257ce63abe",
     "packages": [
         {
             "name": "dflydev/markdown",
@@ -676,16 +676,16 @@
         },
         {
             "name": "mothership-ec/cog",
-            "version": "4.4.0",
+            "version": "4.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog.git",
-                "reference": "31458c092f65b896295ae69aa7f72b221cdfa55d"
+                "reference": "3dd35d79b6845c968e6eab2b8442fa31f5c5a7d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/31458c092f65b896295ae69aa7f72b221cdfa55d",
-                "reference": "31458c092f65b896295ae69aa7f72b221cdfa55d",
+                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/3dd35d79b6845c968e6eab2b8442fa31f5c5a7d4",
+                "reference": "3dd35d79b6845c968e6eab2b8442fa31f5c5a7d4",
                 "shasum": ""
             },
             "require": {
@@ -716,6 +716,7 @@
                 "symfony/finder": "2.2.*",
                 "symfony/form": "2.3.*",
                 "symfony/http-kernel": "2.3.*",
+                "symfony/options-resolver": "2.6.*",
                 "symfony/process": "2.1.*",
                 "symfony/routing": "2.3.*",
                 "symfony/templating": "2.1.*",
@@ -726,7 +727,8 @@
                 "symfony/yaml": "2.1.*",
                 "treasure-chest/treasure-chest": "0.1.*",
                 "twig/twig": "1.13.*",
-                "zendframework/zend-debug": "~2.2.6"
+                "zendframework/zend-debug": "~2.4",
+                "zendframework/zend-escaper": "~2.4"
             },
             "require-dev": {
                 "mikey179/vfsstream": "1.1.*",
@@ -765,7 +767,7 @@
                 "cog",
                 "framework"
             ],
-            "time": "2015-05-22 12:42:01"
+            "time": "2015-06-01 15:31:12"
         },
         {
             "name": "mothership-ec/cog-imageresize",
@@ -817,16 +819,16 @@
         },
         {
             "name": "mothership-ec/cog-mothership-cp",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-cp.git",
-                "reference": "3c5ad768cebd31ad89779df80d16b5cd63408b13"
+                "reference": "d2411d1607c05fb9c196b545f28809256c400c23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-cp/zipball/3c5ad768cebd31ad89779df80d16b5cd63408b13",
-                "reference": "3c5ad768cebd31ad89779df80d16b5cd63408b13",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-cp/zipball/d2411d1607c05fb9c196b545f28809256c400c23",
+                "reference": "d2411d1607c05fb9c196b545f28809256c400c23",
                 "shasum": ""
             },
             "require": {
@@ -863,20 +865,20 @@
                 "control panel",
                 "mothership"
             ],
-            "time": "2015-05-26 15:03:32"
+            "time": "2015-05-27 11:51:18"
         },
         {
             "name": "mothership-ec/cog-mothership-file-manager",
-            "version": "3.0.0",
+            "version": "dev-feature/add-load-by-filename-method",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-file-manager.git",
-                "reference": "2f74adfa9c3b4db67d617cfb390e85ae9a1a95ab"
+                "reference": "e41effb76d694870c7b8cc950dc5b1ff784aceff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-file-manager/zipball/2f74adfa9c3b4db67d617cfb390e85ae9a1a95ab",
-                "reference": "2f74adfa9c3b4db67d617cfb390e85ae9a1a95ab",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-file-manager/zipball/e41effb76d694870c7b8cc950dc5b1ff784aceff",
+                "reference": "e41effb76d694870c7b8cc950dc5b1ff784aceff",
                 "shasum": ""
             },
             "require": {
@@ -898,7 +900,7 @@
             ],
             "authors": [
                 {
-                    "name": "The Message Development Team",
+                    "name": "The Mothership Development Team",
                     "email": "dev@mothership.ec"
                 }
             ],
@@ -916,7 +918,7 @@
                 "upload",
                 "uploads"
             ],
-            "time": "2015-02-24 15:55:58"
+            "time": "2015-06-09 14:07:21"
         },
         {
             "name": "mothership-ec/cog-mothership-reports",
@@ -1108,22 +1110,27 @@
         },
         {
             "name": "natxet/CssMin",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/natxet/CssMin.git",
-                "reference": "afdcdbdb5fc332313f47a79ae60346df3e69a572"
+                "reference": "f076e41392b0008efb47074a133ec1d90dc8c99f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/natxet/CssMin/zipball/afdcdbdb5fc332313f47a79ae60346df3e69a572",
-                "reference": "afdcdbdb5fc332313f47a79ae60346df3e69a572",
+                "url": "https://api.github.com/repos/natxet/CssMin/zipball/f076e41392b0008efb47074a133ec1d90dc8c99f",
+                "reference": "f076e41392b0008efb47074a133ec1d90dc8c99f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1146,7 +1153,7 @@
                 "css",
                 "minify"
             ],
-            "time": "2013-07-02 20:53:35"
+            "time": "2015-05-21 16:53:45"
         },
         {
             "name": "nikic/php-parser",
@@ -1279,23 +1286,23 @@
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.0",
+            "version": "v5.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "31454f258f10329ae7c48763eb898a75c39e0a9f"
+                "reference": "0697e6aa65c83edf97bb0f23d8763f94e3f11421"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/31454f258f10329ae7c48763eb898a75c39e0a9f",
-                "reference": "31454f258f10329ae7c48763eb898a75c39e0a9f",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/0697e6aa65c83edf97bb0f23d8763f94e3f11421",
+                "reference": "0697e6aa65c83edf97bb0f23d8763f94e3f11421",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "mockery/mockery": "~0.9.1"
+                "mockery/mockery": "~0.9.1,<0.9.4"
             },
             "type": "library",
             "extra": {
@@ -1324,24 +1331,25 @@
             "description": "Swiftmailer, free feature-rich PHP mailer",
             "homepage": "http://swiftmailer.org",
             "keywords": [
+                "email",
                 "mail",
                 "mailer"
             ],
-            "time": "2015-03-14 06:06:39"
+            "time": "2015-06-06 14:19:39"
         },
         {
             "name": "symfony/console",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "d446270de14e324e3b52ce82c83a7e33c480c808"
+                "reference": "4ce3d2a448af346068e799a2182c3010ff2ed651"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/d446270de14e324e3b52ce82c83a7e33c480c808",
-                "reference": "d446270de14e324e3b52ce82c83a7e33c480c808",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/4ce3d2a448af346068e799a2182c3010ff2ed651",
+                "reference": "4ce3d2a448af346068e799a2182c3010ff2ed651",
                 "shasum": ""
             },
             "require": {
@@ -1381,25 +1389,24 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-01 14:06:45"
+            "time": "2015-05-24 18:51:45"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Debug",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Debug.git",
-                "reference": "ad4511a8fddce7ec163b513ba39a30ea4f32c9e7"
+                "reference": "1df2971b27a6ff73dae4ea622f42802000ec332d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Debug/zipball/ad4511a8fddce7ec163b513ba39a30ea4f32c9e7",
-                "reference": "ad4511a8fddce7ec163b513ba39a30ea4f32c9e7",
+                "url": "https://api.github.com/repos/symfony/Debug/zipball/1df2971b27a6ff73dae4ea622f42802000ec332d",
+                "reference": "1df2971b27a6ff73dae4ea622f42802000ec332d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=5.3.9",
                 "psr/log": "~1.0"
             },
             "conflict": {
@@ -1418,11 +1425,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Debug\\": ""
                 }
             },
@@ -1442,7 +1449,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-08 13:17:44"
+            "time": "2015-05-22 14:54:25"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1497,17 +1504,17 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "471ef4c1746a640482b81f489e7fca0334375921"
+                "reference": "92c4f1322afa51045f431faad353770e4c9bcc12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/471ef4c1746a640482b81f489e7fca0334375921",
-                "reference": "471ef4c1746a640482b81f489e7fca0334375921",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/92c4f1322afa51045f431faad353770e4c9bcc12",
+                "reference": "92c4f1322afa51045f431faad353770e4c9bcc12",
                 "shasum": ""
             },
             "require": {
@@ -1543,7 +1550,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-06 16:34:36"
+            "time": "2015-05-15 13:28:34"
         },
         {
             "name": "symfony/finder",
@@ -1596,17 +1603,17 @@
         },
         {
             "name": "symfony/form",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Component/Form",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Form.git",
-                "reference": "344ba760b39654518ceb0fc50d265eca4be66803"
+                "reference": "ff67012610bcfd901f56490ff40a0c363e72ece0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Form/zipball/344ba760b39654518ceb0fc50d265eca4be66803",
-                "reference": "344ba760b39654518ceb0fc50d265eca4be66803",
+                "url": "https://api.github.com/repos/symfony/Form/zipball/ff67012610bcfd901f56490ff40a0c363e72ece0",
+                "reference": "ff67012610bcfd901f56490ff40a0c363e72ece0",
                 "shasum": ""
             },
             "require": {
@@ -1621,7 +1628,7 @@
                 "symfony/http-foundation": "~2.2",
                 "symfony/phpunit-bridge": "~2.7",
                 "symfony/translation": "~2.0,>=2.0.5",
-                "symfony/validator": "~2.3.0,>=2.3.20"
+                "symfony/validator": "~2.3.29"
             },
             "suggest": {
                 "symfony/http-foundation": "",
@@ -1654,25 +1661,24 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-01 14:06:45"
+            "time": "2015-05-21 21:12:55"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/HttpFoundation",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/HttpFoundation.git",
-                "reference": "8a0d00980ef9f6b47ddbf24bdfbf70fead760816"
+                "reference": "729de183da037c125c5f6366bd4f0631ba1a1abb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/8a0d00980ef9f6b47ddbf24bdfbf70fead760816",
-                "reference": "8a0d00980ef9f6b47ddbf24bdfbf70fead760816",
+                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/729de183da037c125c5f6366bd4f0631ba1a1abb",
+                "reference": "729de183da037c125c5f6366bd4f0631ba1a1abb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
                 "symfony/expression-language": "~2.4",
@@ -1681,15 +1687,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\HttpFoundation\\": ""
                 },
                 "classmap": [
-                    "Symfony/Component/HttpFoundation/Resources/stubs"
+                    "Resources/stubs"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1708,21 +1714,21 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
+            "time": "2015-05-22 14:54:25"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Component/HttpKernel",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/HttpKernel.git",
-                "reference": "3cee6abfb450af315ac77b3163c03d6bf1237c81"
+                "reference": "985edc8edf03e2464f572f1d2d3f9f2b5538089c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/3cee6abfb450af315ac77b3163c03d6bf1237c81",
-                "reference": "3cee6abfb450af315ac77b3163c03d6bf1237c81",
+                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/985edc8edf03e2464f572f1d2d3f9f2b5538089c",
+                "reference": "985edc8edf03e2464f572f1d2d3f9f2b5538089c",
                 "shasum": ""
             },
             "require": {
@@ -1782,28 +1788,27 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-10 15:02:48"
+            "time": "2015-05-29 22:16:04"
         },
         {
             "name": "symfony/intl",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Intl",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Intl.git",
-                "reference": "12d374531e2bbd43bbe503cdc79f8d00c2f7422a"
+                "reference": "b41de2d387cc71569ee4b8b2f906d3b6cc64984d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Intl/zipball/12d374531e2bbd43bbe503cdc79f8d00c2f7422a",
-                "reference": "12d374531e2bbd43bbe503cdc79f8d00c2f7422a",
+                "url": "https://api.github.com/repos/symfony/Intl/zipball/b41de2d387cc71569ee4b8b2f906d3b6cc64984d",
+                "reference": "b41de2d387cc71569ee4b8b2f906d3b6cc64984d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
-                "symfony/filesystem": ">=2.1",
+                "symfony/filesystem": "~2.1",
                 "symfony/phpunit-bridge": "~2.7"
             },
             "suggest": {
@@ -1812,18 +1817,18 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Intl\\": ""
                 },
                 "classmap": [
-                    "Symfony/Component/Intl/Resources/stubs"
+                    "Resources/stubs"
                 ],
                 "files": [
-                    "Symfony/Component/Intl/Resources/stubs/functions.php"
+                    "Resources/stubs/functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1858,21 +1863,21 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2015-05-02 15:18:45"
+            "time": "2015-05-22 14:54:25"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.6.7",
+            "version": "v2.6.9",
             "target-dir": "Symfony/Component/OptionsResolver",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/OptionsResolver.git",
-                "reference": "ac469b57f9bb4fef66ecf48113476d13ce0bdea4"
+                "reference": "31e56594cee489e9a235b852228b0598b52101c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/OptionsResolver/zipball/ac469b57f9bb4fef66ecf48113476d13ce0bdea4",
-                "reference": "ac469b57f9bb4fef66ecf48113476d13ce0bdea4",
+                "url": "https://api.github.com/repos/symfony/OptionsResolver/zipball/31e56594cee489e9a235b852228b0598b52101c1",
+                "reference": "31e56594cee489e9a235b852228b0598b52101c1",
                 "shasum": ""
             },
             "require": {
@@ -1913,7 +1918,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2015-05-02 15:18:45"
+            "time": "2015-05-13 11:33:56"
         },
         {
             "name": "symfony/process",
@@ -1961,21 +1966,20 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/PropertyAccess",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/PropertyAccess.git",
-                "reference": "1a913a7c2f2441e37485c79e658a261350546351"
+                "reference": "bc738f091816455d5c30b99f5a8d714469b44ad4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/1a913a7c2f2441e37485c79e658a261350546351",
-                "reference": "1a913a7c2f2441e37485c79e658a261350546351",
+                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/bc738f091816455d5c30b99f5a8d714469b44ad4",
+                "reference": "bc738f091816455d5c30b99f5a8d714469b44ad4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
                 "symfony/phpunit-bridge": "~2.7"
@@ -1983,11 +1987,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\PropertyAccess\\": ""
                 }
             },
@@ -2018,21 +2022,21 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2015-05-02 15:18:45"
+            "time": "2015-05-12 15:01:57"
         },
         {
             "name": "symfony/routing",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Component/Routing",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Routing.git",
-                "reference": "d4181ab9f26e3bb7430f49aa2956e8ea6568630f"
+                "reference": "00a6c79757f34aabbdf9afa2094df1b28639a3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Routing/zipball/d4181ab9f26e3bb7430f49aa2956e8ea6568630f",
-                "reference": "d4181ab9f26e3bb7430f49aa2956e8ea6568630f",
+                "url": "https://api.github.com/repos/symfony/Routing/zipball/00a6c79757f34aabbdf9afa2094df1b28639a3c9",
+                "reference": "00a6c79757f34aabbdf9afa2094df1b28639a3c9",
                 "shasum": ""
             },
             "require": {
@@ -2078,7 +2082,7 @@
             ],
             "description": "Symfony Routing Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-01 14:06:45"
+            "time": "2015-05-15 13:28:34"
         },
         {
             "name": "symfony/templating",
@@ -2126,17 +2130,17 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Component/Translation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Translation.git",
-                "reference": "ab156d547f6b8774ea8760174928a1c775aec4c7"
+                "reference": "0e1d974b84ccc30fb59aec852dbe6b7562f79e54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/ab156d547f6b8774ea8760174928a1c775aec4c7",
-                "reference": "ab156d547f6b8774ea8760174928a1c775aec4c7",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/0e1d974b84ccc30fb59aec852dbe6b7562f79e54",
+                "reference": "0e1d974b84ccc30fb59aec852dbe6b7562f79e54",
                 "shasum": ""
             },
             "require": {
@@ -2179,21 +2183,21 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-01 14:06:45"
+            "time": "2015-05-28 20:42:23"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Bridge/Twig",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/TwigBridge.git",
-                "reference": "ed28bdd66dbbf7134a95fe3fbb2a6a1df6fbf00e"
+                "reference": "620f41bddb01ac8077e38396a39ecaec2a717b36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/TwigBridge/zipball/ed28bdd66dbbf7134a95fe3fbb2a6a1df6fbf00e",
-                "reference": "ed28bdd66dbbf7134a95fe3fbb2a6a1df6fbf00e",
+                "url": "https://api.github.com/repos/symfony/TwigBridge/zipball/620f41bddb01ac8077e38396a39ecaec2a717b36",
+                "reference": "620f41bddb01ac8077e38396a39ecaec2a717b36",
                 "shasum": ""
             },
             "require": {
@@ -2249,21 +2253,21 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2015-05-01 14:06:45"
+            "time": "2015-05-20 00:44:44"
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Bundle/TwigBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/TwigBundle.git",
-                "reference": "b84b3793c0cb524454a33be2d719c34535a4afb5"
+                "reference": "ce4445f53ecab4f8eeecc7fa198ac3f0d2ffb9b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/TwigBundle/zipball/b84b3793c0cb524454a33be2d719c34535a4afb5",
-                "reference": "b84b3793c0cb524454a33be2d719c34535a4afb5",
+                "url": "https://api.github.com/repos/symfony/TwigBundle/zipball/ce4445f53ecab4f8eeecc7fa198ac3f0d2ffb9b8",
+                "reference": "ce4445f53ecab4f8eeecc7fa198ac3f0d2ffb9b8",
                 "shasum": ""
             },
             "require": {
@@ -2305,21 +2309,21 @@
             ],
             "description": "Symfony TwigBundle",
             "homepage": "https://symfony.com",
-            "time": "2015-05-01 14:06:45"
+            "time": "2015-05-29 14:42:01"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.3.28",
+            "version": "v2.3.30",
             "target-dir": "Symfony/Component/Validator",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Validator.git",
-                "reference": "105e8c3b2925136a725d3cc1c37f66ced7e3b0e4"
+                "reference": "fac8d90f07df7b092bb1b4d27a4be1f75233dbfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Validator/zipball/105e8c3b2925136a725d3cc1c37f66ced7e3b0e4",
-                "reference": "105e8c3b2925136a725d3cc1c37f66ced7e3b0e4",
+                "url": "https://api.github.com/repos/symfony/Validator/zipball/fac8d90f07df7b092bb1b4d27a4be1f75233dbfe",
+                "reference": "fac8d90f07df7b092bb1b4d27a4be1f75233dbfe",
                 "shasum": ""
             },
             "require": {
@@ -2368,7 +2372,7 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-01 14:06:45"
+            "time": "2015-05-28 03:26:02"
         },
         {
             "name": "symfony/yaml",
@@ -2513,24 +2517,25 @@
         },
         {
             "name": "zendframework/zend-debug",
-            "version": "2.2.10",
-            "target-dir": "Zend/Debug",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-debug.git",
-                "reference": "792f2015009bc182a5c9e6fd1b98fdfcfbcb717b"
+                "reference": "b6f9df59155391ca683c479a0d758f66ef73b3b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-debug/zipball/5cdd04f1822366b754fc041b0134628bc66ccc41",
-                "reference": "792f2015009bc182a5c9e6fd1b98fdfcfbcb717b",
+                "url": "https://api.github.com/repos/zendframework/zend-debug/zipball/b6f9df59155391ca683c479a0d758f66ef73b3b3",
+                "reference": "b6f9df59155391ca683c479a0d758f66ef73b3b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.23"
             },
             "require-dev": {
-                "zendframework/zend-escaper": "*"
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-escaper": "2.*"
             },
             "suggest": {
                 "ext/xdebug": "XDebug, for better backtrace output",
@@ -2539,24 +2544,69 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Zend\\Debug\\": ""
+                "psr-4": {
+                    "Zend\\Debug\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
+            "homepage": "https://github.com/zendframework/zend-debug",
             "keywords": [
                 "debug",
                 "zf2"
             ],
-            "time": "2015-02-17 20:01:36"
+            "time": "2015-06-03 14:05:35"
+        },
+        {
+            "name": "zendframework/zend-escaper",
+            "version": "2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-escaper.git",
+                "reference": "a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73",
+                "reference": "a4b227d8a477f4e7e9073f8e0a7ae7dbd3104a73",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.23"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Escaper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-escaper",
+            "keywords": [
+                "escaper",
+                "zf2"
+            ],
+            "time": "2015-06-03 14:05:37"
         }
     ],
     "packages-dev": [
@@ -2671,9 +2721,17 @@
             "time": "2015-05-12 15:28:09"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "3.1.0",
+            "alias_normalized": "3.1.0.0",
+            "version": "dev-feature/add-load-by-filename-method",
+            "package": "mothership-ec/cog-mothership-file-manager"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
+        "mothership-ec/cog-mothership-file-manager": 20,
         "mockery/mockery": 20
     },
     "prefer-stable": false,

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -535,6 +535,13 @@ class Services implements ServicesInterface
 			return new Commerce\Form\Product\Image\Delete;
 		});
 
+		$services['product.image.assignor'] = function($c) {
+			return new Commerce\Product\Image\Assignor(
+				$c['file_manager.file.loader'],
+				$c['locale']
+			);
+		};
+
 		$services['product.unit.loader'] = $services->factory(function($c) {
 			return $c['product.loader']->getEntityLoader('units');
 		});
@@ -644,6 +651,14 @@ class Services implements ServicesInterface
 				$c['product.upload.heading_keys']
 			);
 		});
+
+		$services['product.upload.image_create'] = function($c) {
+			return new Commerce\Product\Upload\ProductImageCreate(
+				$c['product.image.assignor'],
+				$c['product.image.create'],
+				$c['product.upload.heading_keys']
+			);
+		};
 
 		$services->extend('field.collection', function($fields, $c) {
 			$fields->add(new \Message\Mothership\Commerce\FieldType\Product($c['product.loader'], $c['commerce.field.product_list']));

--- a/src/Controller/Product/CsvPort.php
+++ b/src/Controller/Product/CsvPort.php
@@ -101,10 +101,10 @@ class CsvPort extends Controller
 					try {
 						$this->get('product.upload.image_create')->save($product, $productRow);
 					} catch (AssignmentException $e) {
-						$this->addFlash('error', 'ms.commerce.product.upload.image.error', [
+						$this->addFlash('error', $this->trans('ms.commerce.product.upload.image.error', [
 							'%message%'     => $e->getMessage(),
 							'%productName%' => $product->name,
-						]);
+						]));
 					}
 
 					$productCount++;

--- a/src/Product/Image/Assignor.php
+++ b/src/Product/Image/Assignor.php
@@ -10,24 +10,45 @@ use Message\Mothership\FileManager\File;
  * @package Message\Mothership\Commerce\Product\Image
  *
  * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class for assigning images to products using minimal details, e.g. filename
  */
 class Assignor
 {
+	/**
+	 * @var File\FileLoader
+	 */
 	private $_fileLoader;
+
+	/**
+	 * @var
+	 */
 	private $_locale;
 
+	/**
+	 * @param File\FileLoader $fileLoader
+	 * @param $locale
+	 */
 	public function __construct(File\FileLoader $fileLoader, $locale)
 	{
 		$this->_fileLoader = $fileLoader;
 		$this->_locale     = $locale;
 	}
 
-	public function assignByName($name, Product $product, $options = [], $type = 'default')
+	/**
+	 * Load image using by the filename, and assign a product to it.
+	 *
+	 * @param string $name                      The filename for the image
+	 * @param Product $product                  The product to assign to the image
+	 * @param array $options                    The product options to assign to the image
+	 * @param string $type                      The type to set against the image
+	 * @throws Exception\AssignmentException    Throws exception if file cannot be found
+	 * @throws Exception\AssignmentException    Throws exception if file is not an image
+	 *
+	 * @return Image                            Returns a new Image instance with the product assigned
+	 */
+	public function assignByName($name, Product $product, array $options = [], $type = 'default')
 	{
-		if (!is_string($type)) {
-			throw new \InvalidArgumentException('Image type must be a string, ' . gettype($type) . ' given');
-		}
-
 		$file = $this->_fileLoader->getByFilename($name);
 
 		if (is_array($file)) {
@@ -40,6 +61,26 @@ class Assignor
 
 		if ($file->typeID !== File\Type::IMAGE) {
 			throw new Exception\AssignmentException('File with name `' . $name . '` is not an image file');
+		}
+
+		return $this->_setProductToImage($product, $file, $options, $type);
+	}
+
+	/**
+	 * Assign the product and the loaded file to an image instance
+	 *
+	 * @param Product $product             The product to assign to the image
+	 * @param File\File $file              The loaded file to assign to the image
+	 * @param array $options               The product options to assign to the image
+	 * @param string $type                 The type to set against the image
+	 * @throws \InvalidArgumentException   Throws exception if $type is not a string
+	 *
+	 * @return Image                       Returns a new Image instance with the product and file assigned
+	 */
+	private function _setProductToImage(Product $product, File\File $file, array $options, $type)
+	{
+		if (!is_string($type)) {
+			throw new \InvalidArgumentException('Image type must be a string, ' . gettype($type) . ' given');
 		}
 
 		$image = new Image;

--- a/src/Product/Image/Assignor.php
+++ b/src/Product/Image/Assignor.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Message\Mothership\Commerce\Product\Image;
+
+use Message\Mothership\Commerce\Product\Product;
+use Message\Mothership\FileManager\File;
+
+/**
+ * Class Assigner
+ * @package Message\Mothership\Commerce\Product\Image
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
+class Assignor
+{
+	private $_fileLoader;
+	private $_locale;
+
+	public function __construct(File\FileLoader $fileLoader, $locale)
+	{
+		$this->_fileLoader = $fileLoader;
+		$this->_locale     = $locale;
+	}
+
+	public function assignByName($name, Product $product, $type = 'default', $options = [])
+	{
+		if (!is_string($type)) {
+			throw new \InvalidArgumentException('Image type must be a string, ' . gettype($type) . ' given');
+		}
+
+		$file = $this->_fileLoader->getByFilename($name);
+
+		if (is_array($file)) {
+			$file = array_shift($file);
+		}
+
+		if (false === $file) {
+			throw new Exception\AssignmentException('Could not find image by name of `' . $name . '`');
+		}
+
+		if ($file->typeID !== File\Type::IMAGE) {
+			throw new Exception\AssignmentException('File with name `' . $name . '` is not an image file');
+		}
+
+		$image = new Image;
+		$image->setFileLoader($this->_fileLoader);
+		$image->product = $product;
+		$image->fileID  = $file->id;
+		$image->locale  = $this->_locale;
+		$image->options = $options;
+		$image->type    = $type;
+
+		return $image;
+	}
+}

--- a/src/Product/Image/Assignor.php
+++ b/src/Product/Image/Assignor.php
@@ -22,7 +22,7 @@ class Assignor
 		$this->_locale     = $locale;
 	}
 
-	public function assignByName($name, Product $product, $type = 'default', $options = [])
+	public function assignByName($name, Product $product, $options = [], $type = 'default')
 	{
 		if (!is_string($type)) {
 			throw new \InvalidArgumentException('Image type must be a string, ' . gettype($type) . ' given');

--- a/src/Product/Image/Exception/AssignmentException.php
+++ b/src/Product/Image/Exception/AssignmentException.php
@@ -2,6 +2,14 @@
 
 namespace Message\Mothership\Commerce\Product\Image\Exception;
 
+/**
+ * Class AssignmentException
+ * @package Message\Mothership\Commerce\Product\Image\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Exception to be thrown when an image cannot be assigned to a product
+ */
 class AssignmentException extends \LogicException
 {
 

--- a/src/Product/Image/Exception/AssignmentException.php
+++ b/src/Product/Image/Exception/AssignmentException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Message\Mothership\Commerce\Product\Image\Exception;
+
+class AssignmentException extends \LogicException
+{
+
+}

--- a/src/Product/Upload/HeadingBuilder.php
+++ b/src/Product/Upload/HeadingBuilder.php
@@ -38,17 +38,17 @@ class HeadingBuilder implements \Countable
 	 * @var array
 	 */
 	private $_prefixCols = [
-		'name' => 'name',
-		'sortName' => 'sortName',
-		'category' => 'category',
-		'brand' => 'brand',
-		'description' => 'description',
-		'shortDescription' => 'shortDescription',
-		'exportDescription' => 'exportDescription',
-		'supplierRef' => 'supplierRef',
-		'defaultImage' => 'defaultImage',
-		'weight' => 'weight',
-		'notes' => 'notes',
+		'name'                       => 'name',
+		'sortName'                   => 'sortName',
+		'category'                   => 'category',
+		'brand'                      => 'brand',
+		'description'                => 'description',
+		'shortDescription'           => 'shortDescription',
+		'exportDescription'          => 'exportDescription',
+		'supplierRef'                => 'supplierRef',
+		'defaultImage'               => 'defaultImage',
+		'weight'                     => 'weight',
+		'notes'                      => 'notes',
 		'exportManufactureCountryID' => 'exportManufactureCountryID',
 	];
 

--- a/src/Product/Upload/HeadingBuilder.php
+++ b/src/Product/Upload/HeadingBuilder.php
@@ -46,6 +46,7 @@ class HeadingBuilder implements \Countable
 		'shortDescription' => 'shortDescription',
 		'exportDescription' => 'exportDescription',
 		'supplierRef' => 'supplierRef',
+		'defaultImage' => 'defaultImage',
 		'weight' => 'weight',
 		'notes' => 'notes',
 		'exportManufactureCountryID' => 'exportManufactureCountryID',

--- a/src/Product/Upload/ProductBuilder.php
+++ b/src/Product/Upload/ProductBuilder.php
@@ -130,7 +130,6 @@ class ProductBuilder
 					return;
 				}
 			}
-
 		}
 
 		$this->_product->type = $this->_productTypes->getDefault();

--- a/src/Product/Upload/ProductImageCreate.php
+++ b/src/Product/Upload/ProductImageCreate.php
@@ -30,7 +30,7 @@ class ProductImageCreate
 		$this->_headingKeys   = $headingKeys;
 	}
 
-	public function save(Product\Product $product, array $row, $type = 'default', $options = [])
+	public function save(Product\Product $product, array $row, $options = [], $type = 'default')
 	{
 		$key = $this->_headingKeys->getKey(self::HEADING_KEY);
 
@@ -41,7 +41,7 @@ class ProductImageCreate
 		$filename = (string) $row[$key];
 
 		if ($filename !== '') {
-			$image = $this->_imageAssignor->assignByName($filename, $product, $type, $options);
+			$image = $this->_imageAssignor->assignByName($filename, $product, $options, $type);
 			$this->_imageCreate->create($image);
 		}
 	}

--- a/src/Product/Upload/ProductImageCreate.php
+++ b/src/Product/Upload/ProductImageCreate.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Message\Mothership\Commerce\Product\Upload;
+
+use Message\Mothership\Commerce\Product;
+
+class ProductImageCreate
+{
+	const HEADING_KEY = 'defaultImage';
+
+	/**
+	 * @var Product\Image\Assignor
+	 */
+	private $_imageAssignor;
+
+	/**
+	 * @var Product\Image\Create
+	 */
+	private $_imageCreate;
+
+	/**
+	 * @var HeadingKeys
+	 */
+	private $_headingKeys;
+
+	public function __construct(Product\Image\Assignor $imageAssignor, Product\Image\Create $imageCreate, HeadingKeys $headingKeys)
+	{
+		$this->_imageAssignor = $imageAssignor;
+		$this->_imageCreate   = $imageCreate;
+		$this->_headingKeys   = $headingKeys;
+	}
+
+	public function save(Product\Product $product, array $row, $type = 'default', $options = [])
+	{
+		$key = $this->_headingKeys->getKey(self::HEADING_KEY);
+
+		if (!array_key_exists($key, $row)) {
+			throw new \LogicException('Key `' . $key . '` does not exist in row');
+		}
+
+		$filename = (string) $row[$key];
+
+		if ($filename !== '') {
+			$image = $this->_imageAssignor->assignByName($filename, $product, $type, $options);
+			$this->_imageCreate->create($image);
+		}
+	}
+
+}

--- a/src/Product/Upload/ProductImageCreate.php
+++ b/src/Product/Upload/ProductImageCreate.php
@@ -4,6 +4,14 @@ namespace Message\Mothership\Commerce\Product\Upload;
 
 use Message\Mothership\Commerce\Product;
 
+/**
+ * Class ProductImageCreate
+ * @package Message\Mothership\Commerce\Product\Upload
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class for using data from CSV to load and an image to the newly created product, and save it
+ */
 class ProductImageCreate
 {
 	const HEADING_KEY = 'defaultImage';
@@ -23,6 +31,11 @@ class ProductImageCreate
 	 */
 	private $_headingKeys;
 
+	/**
+	 * @param Product\Image\Assignor $imageAssignor
+	 * @param Product\Image\Create $imageCreate
+	 * @param HeadingKeys $headingKeys
+	 */
 	public function __construct(Product\Image\Assignor $imageAssignor, Product\Image\Create $imageCreate, HeadingKeys $headingKeys)
 	{
 		$this->_imageAssignor = $imageAssignor;
@@ -30,6 +43,14 @@ class ProductImageCreate
 		$this->_headingKeys   = $headingKeys;
 	}
 
+	/**
+	 * Assign the image to the product using the filename given in the CSV, and save it against the product
+	 *
+	 * @param Product\Product $product
+	 * @param array $row
+	 * @param array $options
+	 * @param string $type
+	 */
 	public function save(Product\Product $product, array $row, $options = [], $type = 'default')
 	{
 		$key = $this->_headingKeys->getKey(self::HEADING_KEY);

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -177,6 +177,8 @@ ms.commerce:
       description: The upload CSV function will create products based on the data that has been uploaded. Please ensure that this data is correct. It will check which columns have been filled and attempt to work out the product type based on that information.
       utf8-note: <strong>Note:</strong> CSVs must have a character encoding of UTF-8, please see the preferences of your spreadsheet software to ensure this is the case.
       no-valid-rows: Could not detect any rows. Note that when exporting the CSV via your spreadsheet software, you must select UTF-8 as the character encoding format. Unfortunately, this is not currently supported by the OS X version of Microsoft Excel.
+      image:
+        error: Could not assign image to product with the name '%productName%' for the following reason: %message%
       csv:
         # these names need to match
         name:
@@ -201,6 +203,9 @@ ms.commerce:
           help:
         supplierRef:
           name: Supplier reference
+          help:
+        defaultImage:
+          name: Default image name (must have already been uploaded)
           help:
         weight:
           name: Weight (grams)
@@ -232,6 +237,7 @@ ms.commerce:
         var_val:
           name: Variant value
           help:
+
       empty: No units have been added yet.
       sku:
         label: SKU


### PR DESCRIPTION
This PR allows users to set the image name to assign to products via the product upload script. It currently only supports one image per product, which will be set as the default, but there is room for it to apply options and image types to it as well.

Relies on https://github.com/mothership-ec/cog-mothership-file-manager/pull/85

### Summary:

+ Adds `Product\Image\Assignor` class for easily assigning images to products
+ Adds `Product\Image\Exception\AssignmentException` to be thrown when an image cannot be assigned to a product
+ Adds `Product\Upload\ProductImageCreate` class, which uses the `Assignor` to assign images to the newly created product based on the data from the CSV, and then save it to the database
+ Adds `defaultImage` column to product upload CSV template 