### PR TITLE
Product option price cache keys

### DIFF
--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -296,11 +296,11 @@ class Product implements Price\PricedInterface
 		$currencyID = $currencyID ?: $this->_defaultCurrency;
 
 		if(!is_string($type)) {
-			throw new \InvalidArgumentException('Argument $type must be of type string, ' . print_r($type, true) . ' given');
+			throw new \InvalidArgumentException('Argument $type must be of type string, ' . gettype($type) . ' given');
 		}
 
 		if(!is_string($currencyID)) {
-			throw new \InvalidArgumentException('Argument $currencyID must be of type string, ' . print_r($currencyID, true) . ' given');
+			throw new \InvalidArgumentException('Argument $currencyID must be of type string, ' . gettype($currencyID) . ' given');
 		}
 		
 		$key = $type . ':' . $currencyID . '#' . serialize($options);

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -294,6 +294,14 @@ class Product implements Price\PricedInterface
 	public function getOptionPrices(array $options, $type = 'retail', $currencyID = null)
 	{
 		$currencyID = $currencyID ?: $this->_defaultCurrency;
+
+		if(!is_string($type)) {
+			throw new \InvalidArgumentException('Argument $type must be of type string, ' . print_r($type, true) . ' given');
+		}
+
+		if(!is_string($currencyID)) {
+			throw new \InvalidArgumentException('Argument $currencyID must be of type string, ' . print_r($currencyID, true) . ' given');
+		}
 		
 		$key = $type . ':' . $currencyID . '#' . serialize($options);
 

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -293,13 +293,13 @@ class Product implements Price\PricedInterface
 	 */
 	public function getOptionPrices(array $options, $type = 'retail', $currencyID = null)
 	{
-		$key = serialize($options);
+		$currencyID = $currencyID ?: $this->_defaultCurrency;
+		
+		$key = $type . ':' . $currencyID . '#' . serialize($options);
 
 		if (array_key_exists($key, $this->_optionPrices)) {
 			return $this->_optionPrices[$key];
 		}
-
-		$currencyID = $currencyID ?: $this->_defaultCurrency;
 
 		$prices = [];
 


### PR DESCRIPTION
The system was pulling 'rrp' and 'retail' from the same cache. Same seems to be the same with currency. Adding the other method parameters to the key should ensure uniqueness.

### Recration
To recreate, change a product's unit's retail to something lower than the rrp. Then call

`d(product.getOptionPriceTo(optionArray, 'rrp'))`
followed by
`d(product.getOptionPriceTo(optionArray, 'retail'))`.

The prices will printed will be the same, even though the lowest retail is lower than the lowest rrp.

`d(product.getOptionPriceTo(optionArray, 'retail'))`
followed by 
`d(product.getOptionPriceTo(optionArray, 'rrp'))`

Will do the same but in reverse (will always return retail).

### Testing

Do the same as above, but the prices shown should be correct: RRP always showing lower than retail.