### PR TITLE
Updateable product type

### DIFF
--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -278,6 +278,7 @@ class Edit extends Controller
 			$product->notes                       = $data['notes'];
 			$product->weight                      = $data['weight_grams'];
 			$product->exportManufactureCountryID  = $data['export_manufacture_country_id'];
+			$product->type                        = $this->get('product.types')->get($data['product_type']);
 			$product->setExportCode($data['export_code']);
 
 			$product = $productEdit->save($product);

--- a/src/Product/Edit.php
+++ b/src/Product/Edit.php
@@ -210,7 +210,8 @@ class Edit implements TransactionalInterface
 				tax_strategy = :taxStrategy?s,
 				supplier_ref = :supplierRef?sn,
 				weight_grams = :weightGrams?in,
-				category     = :category?sn
+				category     = :category?sn,
+				`type`       = :type?s
 			WHERE
 				product_id = :productID?i
 			", [
@@ -224,6 +225,7 @@ class Edit implements TransactionalInterface
 				'supplierRef'       => $this->_product->supplierRef,
 				'weightGrams'       => $this->_product->weight,
 				'category'          => $this->_product->category,
+				'type'              => $this->_product->type->getName(),
 		]);
 
 		return $this;

--- a/src/Product/Form/ProductAttributes.php
+++ b/src/Product/Form/ProductAttributes.php
@@ -134,7 +134,7 @@ class ProductAttributes extends Handler
 		return $this;
 	}
 
-	protected function _trans($message,  $params = [], $domain = null, $locale = null)
+	protected function _trans($message, array $params = [], $domain = null, $locale = null)
 	{
 		return $this->_container['translator']->trans($message, $params, $domain, $locale);
 

--- a/src/Product/Form/ProductAttributes.php
+++ b/src/Product/Form/ProductAttributes.php
@@ -72,8 +72,7 @@ class ProductAttributes extends Handler
 			[
 				'data' => $product->getExportCode(),
 				'attr' => ['data-help-key' => 'ms.commerce.product.details.export-code.help']
-			]
-		)
+			])
 			->val()
 			->optional()
 		;
@@ -94,15 +93,15 @@ class ProductAttributes extends Handler
 			->number()
 			->optional();
 		$this->add('tags', 'textarea', $this->_trans('ms.commerce.product.details.tags.label'), [
-					'data' => implode(', ', $product->tags),
-					'attr' => ['data-help-key' => 'ms.commerce.product.details.tags.help']
-				])
+				'data' => implode(', ', $product->tags),
+				'attr' => ['data-help-key' => 'ms.commerce.product.details.tags.help']
+			])
 			->val()
 			->optional();
 		$this->add('notes', 'textarea', $this->_trans('ms.commerce.product.details.notes.label'), [
-					'data' => $product->notes,
-					'attr' => ['data-help-key' => 'ms.commerce.product.details.notes.help']
-				])
+				'data' => $product->notes,
+				'attr' => ['data-help-key' => 'ms.commerce.product.details.notes.help']
+			])
 			->val()
 			->optional();
 		$this->add(
@@ -110,10 +109,10 @@ class ProductAttributes extends Handler
 			'choice',
 			$this->_container['translator']->trans('ms.commerce.product.details.export-manufacture-country.label'),
 			[
-							'data' 	  => $product->exportManufactureCountryID,
-							'choices' => $this->_container['country.list']->all(),
-							'attr'    => ['data-help-key' => 'ms.commerce.product.details.export-manufacture-country.help'],
-						]
+				'data' 	  => $product->exportManufactureCountryID,
+				'choices' => $this->_container['country.list']->all(),
+				'attr'    => ['data-help-key' => 'ms.commerce.product.details.export-manufacture-country.help'],
+			]
 		);
 
 		$typeChoices = [];

--- a/src/Product/Form/ProductAttributes.php
+++ b/src/Product/Form/ProductAttributes.php
@@ -11,58 +11,58 @@ class ProductAttributes extends Handler
 	{
 		$this->setName('product-details-edit')
 			->setAction($this->_container['routing.generator']
-				->generate('ms.commerce.product.edit.attributes.action', array('productID' => $product->id))
+				->generate('ms.commerce.product.edit.attributes.action', ['productID' => $product->id])
 			)
 			->setMethod('post');
 
-		$this->add('name', 'text', $this->_trans('ms.commerce.product.attributes.name.label'), array(
-			'data' => $product->name,
-			'attr' => array('data-help-key' => 'ms.commerce.product.attributes.name.help')
-		))
+		$this->add('name', 'text', $this->_trans('ms.commerce.product.attributes.name.label'), [
+				'data' => $product->name,
+				'attr' => ['data-help-key' => 'ms.commerce.product.attributes.name.help']
+			])
 			->val()
 			->maxLength(255);
-		$this->add('display_name', 'text', $this->_trans('ms.commerce.product.attributes.display-name.label'), array(
-			'data' => $product->displayName,
-			'attr' => array('data-help-key' => 'ms.commerce.product.attributes.display-name.help')
-		))
-			->val()
-			->optional()
-			->maxLength(255);
-		$this->add('sort_name', 'text', $this->_trans('ms.commerce.product.attributes.sort-name.label'), array(
-			'data' => $product->sortName,
-			'attr' => array('data-help-key' => 'ms.commerce.product.attributes.sort-name.help')
-		))
+		$this->add('display_name', 'text', $this->_trans('ms.commerce.product.attributes.display-name.label'), [
+				'data' => $product->displayName,
+				'attr' => ['data-help-key' => 'ms.commerce.product.attributes.display-name.help']
+			])
 			->val()
 			->optional()
 			->maxLength(255);
-		$this->add('category', 'datalist', $this->_trans('ms.commerce.product.attributes.category.label'), array(
-			'choices'	=> $this->_getCategories(),
-			'data'		=> $product->category,
-			'attr'		=> array('data-help-key' => 'ms.commerce.product.attributes.category.help')
-		));
-		$this->add('brand', 'datalist', $this->_trans('ms.commerce.product.attributes.brand.label'), array(
-			'data'    => $product->brand,
-			'choices' => $this->_getBrands(),
-			'attr'    => array('data-help-key' => 'ms.commerce.product.attributes.brand.help')
-		))
+		$this->add('sort_name', 'text', $this->_trans('ms.commerce.product.attributes.sort-name.label'), [
+				'data' => $product->sortName,
+				'attr' => ['data-help-key' => 'ms.commerce.product.attributes.sort-name.help']
+			])
+			->val()
+			->optional()
+			->maxLength(255);
+		$this->add('category', 'datalist', $this->_trans('ms.commerce.product.attributes.category.label'), [
+				'choices'	=> $this->_getCategories(),
+				'data'		=> $product->category,
+				'attr'		=> ['data-help-key' => 'ms.commerce.product.attributes.category.help']
+			]);
+		$this->add('brand', 'datalist', $this->_trans('ms.commerce.product.attributes.brand.label'), [
+				'data'    => $product->brand,
+				'choices' => $this->_getBrands(),
+				'attr'    => ['data-help-key' => 'ms.commerce.product.attributes.brand.help']
+			])
 			->val()
 			->maxLength(255)
 			->optional();
-		$this->add('description', 'textarea', $this->_trans('ms.commerce.product.attributes.description.label'), array(
-			'data' => $product->description,
-			'attr' => array('data-help-key' => 'ms.commerce.product.attributes.description.help')
-		))
+		$this->add('description', 'textarea', $this->_trans('ms.commerce.product.attributes.description.label'), [
+				'data' => $product->description,
+				'attr' => ['data-help-key' => 'ms.commerce.product.attributes.description.help']
+			])
 			->val()
 			->optional();
-		$this->add('short_description', 'textarea', $this->_trans('ms.commerce.product.attributes.short-description.label'), array(
-			'data' => $product->shortDescription,
-			'attr' => array('data-help-key' => 'ms.commerce.product.attributes.short-description.help')
-		))
+		$this->add('short_description', 'textarea', $this->_trans('ms.commerce.product.attributes.short-description.label'), [
+				'data' => $product->shortDescription,
+				'attr' => ['data-help-key' => 'ms.commerce.product.attributes.short-description.help']
+			])
 			->val()->optional();
-		$this->add('export_description', 'textarea', $this->_trans('ms.commerce.product.attributes.export-description.label'), array(
-			'data' => $product->exportDescription,
-			'attr' => array('data-help-key' => 'ms.commerce.product.attributes.export-description.help')
-		))
+		$this->add('export_description', 'textarea', $this->_trans('ms.commerce.product.attributes.export-description.label'), [
+				'data' => $product->exportDescription,
+				'attr' => ['data-help-key' => 'ms.commerce.product.attributes.export-description.help']
+			])
 			->val()
 			->optional();
 		$this->add(
@@ -77,43 +77,43 @@ class ProductAttributes extends Handler
 			->val()
 			->optional()
 		;
-		$this->add('supplier_ref', 'text', $this->_trans('ms.commerce.product.details.supplier-ref.label'), array(
-			'data' => $product->supplierRef,
-			'attr' => array('data-help-key' => 'ms.commerce.product.details.supplier-ref.help')
-		))
+		$this->add('supplier_ref', 'text', $this->_trans('ms.commerce.product.details.supplier-ref.label'), [
+				'data' => $product->supplierRef,
+				'attr' => ['data-help-key' => 'ms.commerce.product.details.supplier-ref.help']
+			])
 			->val()
 			->maxLength(255)
 			->optional();
-		$this->add('weight_grams', 'number', $this->_trans('ms.commerce.product.details.weight-grams.label'), array(
-			'data' => $product->weight,
-			'attr' => array(
-				'data-help-key' => 'ms.commerce.product.details.weight-grams.help',
-			)
-		))
+		$this->add('weight_grams', 'number', $this->_trans('ms.commerce.product.details.weight-grams.label'), [
+				'data' => $product->weight,
+				'attr' => [
+					'data-help-key' => 'ms.commerce.product.details.weight-grams.help',
+				]
+			])
 			->val()
 			->number()
 			->optional();
-		$this->add('tags', 'textarea', $this->_trans('ms.commerce.product.details.tags.label'), array(
-			'data' => implode(', ', $product->tags),
-			'attr' => array('data-help-key' => 'ms.commerce.product.details.tags.help')
-		))
+		$this->add('tags', 'textarea', $this->_trans('ms.commerce.product.details.tags.label'), [
+					'data' => implode(', ', $product->tags),
+					'attr' => ['data-help-key' => 'ms.commerce.product.details.tags.help']
+				])
 			->val()
 			->optional();
-		$this->add('notes', 'textarea', $this->_trans('ms.commerce.product.details.notes.label'), array(
-			'data' => $product->notes,
-			'attr' => array('data-help-key' => 'ms.commerce.product.details.notes.help')
-		))
+		$this->add('notes', 'textarea', $this->_trans('ms.commerce.product.details.notes.label'), [
+					'data' => $product->notes,
+					'attr' => ['data-help-key' => 'ms.commerce.product.details.notes.help']
+				])
 			->val()
 			->optional();
 		$this->add(
 			'export_manufacture_country_id',
 			'choice',
 			$this->_container['translator']->trans('ms.commerce.product.details.export-manufacture-country.label'),
-			array(
-				'data' 	  => $product->exportManufactureCountryID,
-				'choices' => $this->_container['country.list']->all(),
-				'attr'    => array('data-help-key' => 'ms.commerce.product.details.export-manufacture-country.help'),
-			)
+			[
+							'data' 	  => $product->exportManufactureCountryID,
+							'choices' => $this->_container['country.list']->all(),
+							'attr'    => ['data-help-key' => 'ms.commerce.product.details.export-manufacture-country.help'],
+						]
 		);
 
 		$typeChoices = [];
@@ -128,13 +128,14 @@ class ProductAttributes extends Handler
 			[
 				'data'        => $product->type->getName(),
 				'choices'     => $typeChoices,
+				'attr'        => ['data-help-key' => 'ms.commerce.product.details.product-type.help'],
 			]
 		);
 
 		return $this;
 	}
 
-	protected function _trans($message, array $params = array(), $domain = null, $locale = null)
+	protected function _trans($message,  $params = [], $domain = null, $locale = null)
 	{
 		return $this->_container['translator']->trans($message, $params, $domain, $locale);
 

--- a/src/Product/Form/ProductAttributes.php
+++ b/src/Product/Form/ProductAttributes.php
@@ -116,6 +116,21 @@ class ProductAttributes extends Handler
 			)
 		);
 
+		$typeChoices = [];
+
+		foreach ($this->_container['product.types'] as $type) {
+			$typeChoices[$type->getName()] = $type->getDisplayName();
+		}
+
+		$this->add('product_type',
+			'choice',
+			$this->_container['translator']->trans('ms.commerce.product.details.product-type.label'),
+			[
+				'data'        => $product->type->getName(),
+				'choices'     => $typeChoices,
+			]
+		);
+
 		return $this;
 	}
 

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -94,6 +94,9 @@ ms.commerce:
         label: Export value
         help: The nominal cost of the product for export purposes.
     details:
+      product-type:
+        label: Product Type
+        help: The type of product. This determines what content may be set on the product, how much tax is charged, and any special behaviour the product will exhibit.
       supplier-ref:
         label: Supplier Reference
         help: Optionally you can store a reference from the supplier of this product.


### PR DESCRIPTION
### What
This adds the functionality to change a product's type. It doesn't overwrite any product details so if you were to change the type and change it back all of the fields should still exist (unless there are conflicting fields and you save over one)

### How to test

Try changing the product type on the Details tab.