### PR TITLE
Extra validation on item tax reconciling with order product tax

### DIFF
--- a/src/Order/EventListener/ValidateListener.php
+++ b/src/Order/EventListener/ValidateListener.php
@@ -61,6 +61,13 @@ class ValidateListener implements SubscriberInterface
 		}
 	}
 
+	/**
+	 * Recount the item tax and check that it matches the order product tax
+	 *
+	 * @param Order $order
+	 *
+	 * @return bool
+	 */
 	private function _validateTax(Order $order)
 	{
 		$itemTax = 0;

--- a/src/Order/EventListener/ValidateListener.php
+++ b/src/Order/EventListener/ValidateListener.php
@@ -2,6 +2,7 @@
 
 namespace Message\Mothership\Commerce\Order\EventListener;
 
+use Message\Mothership\Commerce\Order\Order;
 use Message\Mothership\Commerce\Order\Events as OrderEvents;
 use Message\Mothership\Commerce\Order\Event;
 use Message\Mothership\Commerce\Order\Status\Status;
@@ -54,5 +55,20 @@ class ValidateListener implements SubscriberInterface
 		if (count($order->getItems()) <= 0) {
 			$event->addError('Order must have items set');
 		}
+
+		if (!$this->_validateTax($order)) {
+			$event->addError('Tax calculation error');
+		}
+	}
+
+	private function _validateTax(Order $order)
+	{
+		$itemTax = 0;
+
+		foreach ($order->getItems() as $item) {
+			$itemTax += $item->getTax();
+		}
+
+		return $order->productTax == $itemTax;
 	}
 }

--- a/src/Order/EventListener/ValidateListener.php
+++ b/src/Order/EventListener/ValidateListener.php
@@ -50,5 +50,9 @@ class ValidateListener implements SubscriberInterface
 		if (!$order->currencyID) {
 			$event->addError('Order must have a currency ID');
 		}
+
+		if (count($order->getItems()) <= 0) {
+			$event->addError('Order must have items set');
+		}
 	}
 }

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -471,12 +471,18 @@ class Order implements PayableInterface, Transaction\RecordInterface
 	 */
 	public function updateTotals()
 	{
+		$items = $this->getItems();
+
+		if (count($items) <= 0) {
+			throw new \LogicException('Cannot update totals, there are no items in this order');
+		}
+
 		$this->productNet      = 0;
 		$this->productDiscount = 0;
 		$this->productTax      = 0;
 		$this->productGross    = 0;
 
-		foreach ($this->items as $item) {
+		foreach ($items as $item) {
 			$this->productNet      += $item->net;
 			$this->productDiscount += $item->discount;
 			$this->productTax      += $item->getTax();

--- a/src/Order/Order.php
+++ b/src/Order/Order.php
@@ -473,10 +473,6 @@ class Order implements PayableInterface, Transaction\RecordInterface
 	{
 		$items = $this->getItems();
 
-		if (count($items) <= 0) {
-			throw new \LogicException('Cannot update totals, there are no items in this order');
-		}
-
 		$this->productNet      = 0;
 		$this->productDiscount = 0;
 		$this->productTax      = 0;


### PR DESCRIPTION
This PR adds more stages of validation for the item tax. An exception will be thrown if the totals are attempted to be updated when there are no items. There is also a check for this on the validation event listener. There is also a validation layer that recounts the item tax and checks it against the tax of the order.

Since we have been unable to recreate the issue with tax not being added to the order, it is difficult to check whether this validation will actually resolve the issue. However, it is important to test that this validation does not block valid orders, especially in non-taxable regions or with non-taxable products, as well as with discounts.