### PR TITLE
Sales by Unit report

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -1127,6 +1127,15 @@ class Services implements ServicesInterface
 			);
 		});
 
+		$services['commerce.sales_by_unit'] = $services->factory(function($c) {
+			return new Commerce\Report\SalesByUnit(
+				$c['db.query.builder.factory'],
+				$c['routing.generator'],
+				$c['event.dispatcher'],
+				$c['currency.supported']
+			);
+		});
+
 		$services['commerce.sales_by_location'] = $services->factory(function($c) {
 			return new Commerce\Report\SalesByLocation(
 				$c['db.query.builder.factory'],
@@ -1155,6 +1164,7 @@ class Services implements ServicesInterface
 				->add($c['commerce.sales_by_order'])
 				->add($c['commerce.sales_by_item'])
 				->add($c['commerce.sales_by_product'])
+				->add($c['commerce.sales_by_unit'])
 				->add($c['commerce.sales_by_location'])
 				->add($c['commerce.sales_by_user'])
 			;

--- a/src/Report/AbstractSales.php
+++ b/src/Report/AbstractSales.php
@@ -35,7 +35,7 @@ abstract class AbstractSales extends AbstractReport
 		array $currencies
 	)
 	{
-		parent::__construct($builderFactory, $routingGenerator, $eventDispatcher, $currencies);
+		parent::__construct($builderFactory, $routingGenerator, $eventDispatcher);
 		$this->_eventDispatcher = $eventDispatcher;
 		$this->_charts[]   = new TableChart;
 		$this->_filters->add(new DateRange);

--- a/src/Report/SalesByProduct.php
+++ b/src/Report/SalesByProduct.php
@@ -85,9 +85,9 @@ class SalesByProduct extends AbstractSales
 		;
 
 		// Filter type
-		if($this->_filters->exists('type')) {
+		if ($this->_filters->exists('type')) {
 			$type = $this->_filters->get('type');
-			if($type = $type->getChoices()) {
+			if ($type = $type->getChoices()) {
 				is_array($type) ?
 					$queryBuilder->where('Type IN (?js)', [$type]) :
 					$queryBuilder->where('Type = (?s)', [$type])
@@ -137,10 +137,9 @@ class SalesByProduct extends AbstractSales
 					(int) $row->NumberSold,
 				];
 			}
+
 			return json_encode($result);
-
 		} else {
-
 			foreach ($data as $row) {
 				$result[] = [
 					ucwords($row->Product),
@@ -151,6 +150,7 @@ class SalesByProduct extends AbstractSales
 					$row->NumberSold
 				];
 			}
+
 			return $result;
 		}
 	}

--- a/src/Report/SalesByProduct.php
+++ b/src/Report/SalesByProduct.php
@@ -47,12 +47,12 @@ class SalesByProduct extends AbstractSales
 	public function getColumns()
 	{
 		return [
-			'Product'     => 'string',
-			'Currency'    => 'string',
-			'Net'         => 'number',
-			'Tax'         => 'number',
-			'Gross'       => 'number',
-			'Number Sold' => 'number',
+			'Product'      => 'string',
+			'Currency'     => 'string',
+			'Net'          => 'number',
+			'Tax'          => 'number',
+			'Gross'        => 'number',
+			'Transactions' => 'number',
 		];
 	}
 

--- a/src/Report/SalesByProduct.php
+++ b/src/Report/SalesByProduct.php
@@ -48,7 +48,6 @@ class SalesByProduct extends AbstractSales
 	{
 		return [
 			'Product'     => 'string',
-			'Option'      => 'string',
 			'Currency'    => 'string',
 			'Net'         => 'number',
 			'Tax'         => 'number',
@@ -74,7 +73,6 @@ class SalesByProduct extends AbstractSales
 		$queryBuilder
 			->select('totals.product_id AS "ID"')
 			->select('totals.product AS "Product"')
-			->select('totals.option AS "Option"')
 			->select('totals.currency AS "Currency"')
 			->select('SUM(totals.net) AS "Net"')
 			->select('SUM(totals.tax) AS "Tax"')
@@ -123,7 +121,6 @@ class SalesByProduct extends AbstractSales
 							.ucwords($row->Product).'</a>'
 						]
 						: $row->Product,
-					ucwords($row->Option),
 					$row->Currency,
 					[
 						'v' => (float) $row->Net,
@@ -147,7 +144,6 @@ class SalesByProduct extends AbstractSales
 			foreach ($data as $row) {
 				$result[] = [
 					ucwords($row->Product),
-					ucwords($row->Option),
 					$row->Currency,
 					$row->Net,
 					$row->Tax,

--- a/src/Report/SalesByUnit.php
+++ b/src/Report/SalesByUnit.php
@@ -6,6 +6,12 @@ use Message\Cog\DB\QueryBuilderFactory;
 use Message\Cog\Routing\UrlGenerator;
 use Message\Cog\Event\DispatcherInterface;
 
+/**
+ * Class SalesByUnit
+ * @package Message\Mothership\Commerce\Report
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
 class SalesByUnit extends AbstractSales
 {
 	public function __construct(
@@ -28,6 +34,9 @@ class SalesByUnit extends AbstractSales
 		$this->getFilters()->get('date_range')->setStartDate($startDate->setTimestamp(strtotime(date('Y-m-d H:i')." -1 month")));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function getColumns()
 	{
 		return [
@@ -41,6 +50,9 @@ class SalesByUnit extends AbstractSales
 		];
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function _getQuery()
 	{
 		$fromQuery = $this->_getFilteredQuery();
@@ -57,6 +69,7 @@ class SalesByUnit extends AbstractSales
 			->select('COUNT(totals.gross) AS "Transactions"')
 			->from('totals', $fromQuery)
 			->orderBy('totals.gross DESC')
+			// Group by product name and option string as unioned 'totals' parent query does not get unit ID
 			->groupBy('totals.product, totals.option, currency')
 		;
 
@@ -75,6 +88,9 @@ class SalesByUnit extends AbstractSales
 		return $queryBuilder->getQuery();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function _dataTransform($data, $output = null)
 	{
 		$result = [];

--- a/src/Report/SalesByUnit.php
+++ b/src/Report/SalesByUnit.php
@@ -31,13 +31,13 @@ class SalesByUnit extends AbstractSales
 	public function getColumns()
 	{
 		return [
-			'Product'     => 'string',
-			'Option'      => 'string',
-			'Currency'    => 'string',
-			'Net'         => 'number',
-			'Tax'         => 'number',
-			'Gross'       => 'number',
-			'Number Sold' => 'number',
+			'Product'      => 'string',
+			'Option'       => 'string',
+			'Currency'     => 'string',
+			'Net'          => 'number',
+			'Tax'          => 'number',
+			'Gross'        => 'number',
+			'Transactions' => 'number',
 		];
 	}
 
@@ -49,18 +49,15 @@ class SalesByUnit extends AbstractSales
 		$queryBuilder
 			->select('totals.product_id AS "Product_ID"')
 			->select('totals.product AS "Product"')
-//			->select('totals.unit_id AS "ID"')
 			->select('totals.option AS "Option"')
 			->select('totals.currency AS "Currency"')
 			->select('SUM(totals.net) AS "Net"')
 			->select('SUM(totals.tax) AS "Tax"')
 			->select('SUM(totals.gross) AS "Gross"')
-			->select('COUNT(totals.gross) AS "NumberSold"')
+			->select('COUNT(totals.gross) AS "Transactions"')
 			->from('totals', $fromQuery)
-			->leftJoin('oi', 'oi.order_id = totals.order_id', 'order_item')
-			->where('oi.unit_id IS NOT NULL')
 			->orderBy('totals.gross DESC')
-			->groupBy('oi.unit_id, currency')
+			->groupBy('totals.product, totals.option, currency')
 		;
 
 		if ($this->_filters->exists('type')) {
@@ -106,11 +103,11 @@ class SalesByUnit extends AbstractSales
 						'v' => (float) $row->Gross,
 						'f' => (string) number_format($row->Gross,2,'.',',')
 					],
-					(int) $row->NumberSold,
+					(int) $row->Transactions,
 				];
-
-				return json_encode($result);
 			}
+
+			return json_encode($result);
 		} else {
 			foreach ($data as $row) {
 				$result[] = [
@@ -119,11 +116,11 @@ class SalesByUnit extends AbstractSales
 					$row->Currency,
 					$row->Net,
 					$row->Gross,
-					$row->NumberSold
+					$row->Transactions
 				];
-
-				return $result;
 			}
+
+			return $result;
 		}
 	}
 }

--- a/src/Report/SalesByUnit.php
+++ b/src/Report/SalesByUnit.php
@@ -2,20 +2,9 @@
 
 namespace Message\Mothership\Commerce\Report;
 
-use Message\Cog\DB\QueryBuilderInterface;
 use Message\Cog\DB\QueryBuilderFactory;
 use Message\Cog\Routing\UrlGenerator;
 use Message\Cog\Event\DispatcherInterface;
-
-use Message\Mothership\Report\Report\AbstractReport;
-use Message\Mothership\Report\Event\ReportEvent;
-use Message\Mothership\Report\Chart\TableChart;
-use Message\Mothership\Report\Filter\DateRange;
-use Message\Mothership\Report\Filter\Choices;
-use Message\Mothership\Report\Filter\Collection as FilterCollecion;
-
-use Message\Mothership\Commerce\Events;
-
 
 class SalesByUnit extends AbstractSales
 {
@@ -52,9 +41,89 @@ class SalesByUnit extends AbstractSales
 		];
 	}
 
-	protected function _dataTransform($data, $output = null)
-	{}
-
 	protected function _getQuery()
-	{}
+	{
+		$fromQuery = $this->_getFilteredQuery();
+
+		$queryBuilder = $this->_builderFactory->getQueryBuilder();
+		$queryBuilder
+			->select('totals.product_id AS "Product_ID"')
+			->select('totals.product AS "Product"')
+//			->select('totals.unit_id AS "ID"')
+			->select('totals.option AS "Option"')
+			->select('totals.currency AS "Currency"')
+			->select('SUM(totals.net) AS "Net"')
+			->select('SUM(totals.tax) AS "Tax"')
+			->select('SUM(totals.gross) AS "Gross"')
+			->select('COUNT(totals.gross) AS "NumberSold"')
+			->from('totals', $fromQuery)
+			->leftJoin('oi', 'oi.order_id = totals.order_id', 'order_item')
+			->where('oi.unit_id IS NOT NULL')
+			->orderBy('totals.gross DESC')
+			->groupBy('oi.unit_id, currency')
+		;
+
+		if ($this->_filters->exists('type')) {
+
+			$type = $this->_filters->get('type');
+
+			if ($type = $type->getChoices()) {
+				is_array($type) ?
+					$queryBuilder->where('Type IN (?js)', [$type]) :
+					$queryBuilder->where('Type = ?s', [$type])
+				;
+			}
+		}
+
+		return $queryBuilder->getQuery();
+	}
+
+	protected function _dataTransform($data, $output = null)
+	{
+		$result = [];
+
+		if ($output === 'json') {
+			foreach ($data as $row) {
+				$result[] = [
+					$row->Product_ID ?
+						[
+							'v' => ucwords($row->Product),
+							'f' => (string) '<a href ="'.$this->generateUrl('ms.commerce.product.edit.attributes', ['productID' => $row->Product_ID]).'">'
+								.ucwords($row->Product).'</a>'
+						]
+						: $row->Product,
+					$row->Option,
+					$row->Currency,
+					[
+						'v' => (float) $row->Net,
+						'f' => (string) number_format($row->Net,2,'.',',')
+					],
+					[
+						'v' => (float) $row->Tax,
+						'f' => (string) number_format($row->Tax,2,'.',',')
+					],
+					[
+						'v' => (float) $row->Gross,
+						'f' => (string) number_format($row->Gross,2,'.',',')
+					],
+					(int) $row->NumberSold,
+				];
+
+				return json_encode($result);
+			}
+		} else {
+			foreach ($data as $row) {
+				$result[] = [
+					ucwords($row->Product),
+					$row->Option,
+					$row->Currency,
+					$row->Net,
+					$row->Gross,
+					$row->NumberSold
+				];
+
+				return $result;
+			}
+		}
+	}
 }

--- a/src/Report/SalesByUnit.php
+++ b/src/Report/SalesByUnit.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Message\Mothership\Commerce\Report;
+
+use Message\Cog\DB\QueryBuilderInterface;
+use Message\Cog\DB\QueryBuilderFactory;
+use Message\Cog\Routing\UrlGenerator;
+use Message\Cog\Event\DispatcherInterface;
+
+use Message\Mothership\Report\Report\AbstractReport;
+use Message\Mothership\Report\Event\ReportEvent;
+use Message\Mothership\Report\Chart\TableChart;
+use Message\Mothership\Report\Filter\DateRange;
+use Message\Mothership\Report\Filter\Choices;
+use Message\Mothership\Report\Filter\Collection as FilterCollecion;
+
+use Message\Mothership\Commerce\Events;
+
+
+class SalesByUnit extends AbstractSales
+{
+	public function __construct(
+		QueryBuilderFactory $builderFactory,
+		UrlGenerator $routingGenerator,
+		DispatcherInterface $eventDispatcher,
+		array $currencies
+	)
+	{
+		parent::__construct($builderFactory, $routingGenerator, $eventDispatcher, $currencies);
+
+		$this->_setName('sales_by_unit');
+		$this->_setDisplayName('Sales by Unit');
+		$this->_setReportGroup('Sales');
+		$this->_setDescription('
+			This report groups the total income by unit.
+			By default it includes all data(orders, returns, shipping) from the last month (by completed date)
+		');
+		$startDate = new \DateTime;
+		$this->getFilters()->get('date_range')->setStartDate($startDate->setTimestamp(strtotime(date('Y-m-d H:i')." -1 month")));
+	}
+
+	public function getColumns()
+	{
+		return [
+			'Product'     => 'string',
+			'Option'      => 'string',
+			'Currency'    => 'string',
+			'Net'         => 'number',
+			'Tax'         => 'number',
+			'Gross'       => 'number',
+			'Number Sold' => 'number',
+		];
+	}
+
+	protected function _dataTransform($data, $output = null)
+	{}
+
+	protected function _getQuery()
+	{}
+}


### PR DESCRIPTION
This PR adds a 'Sales by Unit' report, which works similarly to the 'Sales by Product' report, but displays individual units rather than products as a whole. Unfortunately, the main sales query does not return unit ids, and this cannot be changed without breaking BC as this query is unioned onto queries in other modules. To get around this, units are grouped by their product name and option string.

Also included in this PR:

+ The 'Option' column on the product report has been removed
+ 'Number Sold' columns have been renamed 'Transactions'