### PR TITLE
do not show images on product listing if there are over 1000 products

### DIFF
--- a/resources/assets/js/setup.js
+++ b/resources/assets/js/setup.js
@@ -1,6 +1,9 @@
 $(function() {
+
 	// Product table JS setup
-	var dataTable = $('.table-filter.products').dataTable({
+	var	showImages = $('.table-filter.products').data('show-images'),
+		columns = getColumns(),
+		dataTable = $('.table-filter.products').dataTable({
 		iDisplayLength: 25,
 		"oLanguage": {
 			"sLengthMenu": 'Display <select>'+
@@ -12,19 +15,28 @@ $(function() {
 			'</select> products',
 		"sInfo": "Showing (_START_ to _END_) of _TOTAL_ Products"}
     }).columnFilter({
-		aoColumns: [
+		aoColumns: columns
+	});
+
+	function getColumns() {
+		columns = [
 			{ type: "text" },
 			null,
 			{ type: "text" },
 			{ type: "text" },
 			{ type: "text" },
 			null
-		]
-	});
+		];
 
+		if (!showImages) {
+			columns.splice(1,1);
+		}
+
+		return columns;
+	}
 
     // Hide and show columns when ajax slide happens
-	var showCol = 2;
+	var showCol = showImages ? 2 : 1;
 	$('#main-slide').on('show.cp-livePane-slide', function(e, data) {
 		$('.dataTables_length').hide();
 

--- a/resources/view/product/product-table.html.twig
+++ b/resources/view/product/product-table.html.twig
@@ -5,11 +5,14 @@
 		<a href="{{ url('ms.commerce.product.create')}}" class="button small create product" data-live>Add a new product</a>
 	</div>
 </hgroup>
+
 <div class="container-content">
-	<table class="table-filter products">
+	<table class="table-filter products" data-show-images="{{ showImages ? "true" : "false" }}">
 		<colgroup>
 			<col width="100">
-            <col width="50">
+			{% if showImages %}
+				<col width="50">
+			{% endif %}
             <col>
             <col>
             <col>
@@ -19,7 +22,9 @@
 		<thead>
 			<tr>
 				<th>ID</th>
-				<th class="disable">Photo</th>
+				{% if showImages %}
+					<th class="disable">Photo</th>
+				{% endif %}
 				<th>Name</th>
 				<th>Brand</th>
 				<th>Category</th>
@@ -30,7 +35,9 @@
 		<tfoot>
 			<tr>
 				<th>ID</th>
-				<th>-</th>
+				{% if showImages %}
+					<th>-</th>
+				{% endif %}
 				<th>Name</th>
 				<th>Brand</th>
 				<th>Category</th>
@@ -42,7 +49,9 @@
 			{% for product in products %}
 				<tr>
 					<td>{{ product.id }}</td>
-					<td>{{ getResizedImage(product.getImage(), 50, 50) }}</td>
+					{% if showImages %}
+						<td>{{ getResizedImage(product.getImage(), 50, 50) }}</td>
+					{% endif %}
 					<td><a href="{{ url('ms.commerce.product.edit.attributes', {productID:product.id}) }}" class="click" data-live>{{ product.defaultName }}</a></td>
 					<td>{{ product.brand }}</td>
 					<td>{{ product.category }}</td>

--- a/src/Controller/Product/Dashboard.php
+++ b/src/Controller/Product/Dashboard.php
@@ -15,6 +15,8 @@ class Dashboard extends Controller
 
 	public function productTable()
 	{
+		$imageThreshold = 1000;
+
 		// skip loading all the products if ajax request
 		if ($this->get('request')->server->has('HTTP_X_REQUESTED_WITH') && 
 			strtolower($this->get('request')->server->get('HTTP_X_REQUESTED_WITH')) == 'xmlhttprequest') {
@@ -28,10 +30,10 @@ class Dashboard extends Controller
 
 		$products = $this->get('product.loader')->getAll();
 
-
 		return $this->render('Message:Mothership:Commerce::product:product-table', [
 			'products' => $products,
-			'dashboardReferences' => $event->getReferences()
+			'dashboardReferences' => $event->getReferences(),
+			'showImages' => count($products) < $imageThreshold,
 		]);
 	}
 }


### PR DESCRIPTION
This PR stops images from loading on the product listing if there are over 1000 products in the database. This is merely a temporary fix for the larger issue of needing pagination with ajax loading on this screen (https://github.com/mothership-ec/cog-mothership-commerce/issues/452)