### PR TITLE
Allow for multiple types of discount and resolve issues with discount calculations

### DIFF
--- a/resources/migrations/_1437641846_DiscountTypeField.php
+++ b/resources/migrations/_1437641846_DiscountTypeField.php
@@ -1,0 +1,37 @@
+<?php
+
+use Message\Cog\Migration\Adapter\MySQL\Migration;
+
+class _1437641846_DiscountTypeField extends Migration
+{
+	public function up()
+	{
+		$this->run("
+			ALTER TABLE
+				order_discount
+			ADD
+				`type` VARCHAR(255) DEFAULT NULL
+			AFTER
+				created_by
+		");
+
+		$this->run("
+			UPDATE
+				order_discount
+			SET
+				`type` = 'code'
+			WHERE
+				code IS NOT NULL
+			");
+	}
+
+	public function down()
+	{
+		$this->run("
+			ALTER TABLE
+				order_discount
+			DROP COLUMN
+				code
+		");
+	}
+}

--- a/src/Controller/Module/Basket.php
+++ b/src/Controller/Module/Basket.php
@@ -10,14 +10,16 @@ class Basket extends Controller
 	{
 		$order          = $this->get('basket')->getOrder();
 		$totalListPrice = 0;
+		$totalDiscount  = 0;
 
 		foreach ($order->items as $item) {
 			$totalListPrice += $item->listPrice;
+			$totalDiscount  += $item->discount;
 		}
 
 		return $this->render('Message:Mothership:Commerce::basket', array(
 			'order'          => $order,
-			'totalListPrice' => $totalListPrice,
+			'totalListPrice' => $totalListPrice - $totalDiscount,
 		));
 	}
 }

--- a/src/Order/Entity/Discount/Collection.php
+++ b/src/Order/Entity/Discount/Collection.php
@@ -41,4 +41,15 @@ class Collection extends BaseCollection
 
 		return false;
 	}
+
+	public function getTotal()
+	{
+		$total = 0;
+
+		foreach ($this->_items as $discount) {
+			$total += $discount->discount;
+		}
+
+		return $total;
+	}
 }

--- a/src/Order/Entity/Discount/Create.php
+++ b/src/Order/Entity/Discount/Create.php
@@ -49,15 +49,17 @@ class Create implements DB\TransactionalInterface
 				order_id    = :orderID?i,
 				created_at  = :createdAt?d,
 				created_by  = :createdBy?in,
+				`type`      = :type?sn,
 				code        = :code?sn,
 				amount      = :amount?f,
 				percentage  = :percentage?fn,
-				name        = :name?sn,
+				`name`      = :name?sn,
 				description = :description?sn
 		', array(
 			'orderID'     => $discount->order->id,
 			'createdAt'   => $discount->authorship->createdAt(),
 			'createdBy'   => $discount->authorship->createdBy(),
+			'type'        => $discount->getType(),
 			'code'        => $discount->code,
 			'amount'      => $discount->amount,
 			'percentage'  => $discount->percentage,

--- a/src/Order/Entity/Discount/Discount.php
+++ b/src/Order/Entity/Discount/Discount.php
@@ -28,6 +28,8 @@ class Discount implements EntityInterface
 	public $name;
 	public $description;
 
+	private $_type;
+
 	public function __construct()
 	{
 		$this->authorship = new Authorship;
@@ -37,5 +39,19 @@ class Discount implements EntityInterface
 			->disableDelete();
 
 		$this->items = new Item\Collection;
+	}
+
+	public function setType($type)
+	{
+		if ($type && !is_string($type)) {
+			throw new \InvalidArgumentException('Discount type must be a string');
+		}
+
+		$this->_type = $type;
+	}
+
+	public function getType()
+	{
+		return $this->_type;
 	}
 }

--- a/src/Order/Entity/Discount/EventListener.php
+++ b/src/Order/Entity/Discount/EventListener.php
@@ -86,9 +86,9 @@ class EventListener extends BaseListener implements SubscriberInterface
 		foreach ($event->getOrder()->discounts as $discount) {
 			if ($discount->percentage) {
 				foreach ($discount->items as $item) {
-					$amount            = round($item->basePrice * ($discount->percentage / 100), 2);
-					$item->discount   += $amount;
-					$discount->amount += $amount;
+					$amount                = round($item->basePrice * ($discount->percentage / 100), 2);
+					$item->discount       += $amount;
+					$discount->amount     += $amount;
 				}
 			}
 			else {

--- a/src/Order/Entity/Discount/EventListener.php
+++ b/src/Order/Entity/Discount/EventListener.php
@@ -114,7 +114,7 @@ class EventListener extends BaseListener implements SubscriberInterface
 				->setAssignProrateAmount(
 					function($item, $proratedValue)
 					{
-						$item->discount += round($proratedValue, 2);
+						$item->discount += $proratedValue;
 					}
 				);
 			$prorateHelper->prorateValue($discount->amount, $discount->items->all());
@@ -122,9 +122,9 @@ class EventListener extends BaseListener implements SubscriberInterface
 
 		foreach ($percentages as $discount) {
 			foreach ($discount->items as $item) {
-				$amount                = round($item->getDiscountedPrice() * ($discount->percentage / 100), 2);
-				$item->discount       += $amount;
-				$discount->amount     += $amount;
+				$amount            = $item->getDiscountedPrice() * ($discount->percentage / 100);
+				$item->discount   += $amount;
+				$discount->amount += $amount;
 			}
 		}
 	}

--- a/src/Order/Entity/Discount/EventListener.php
+++ b/src/Order/Entity/Discount/EventListener.php
@@ -83,38 +83,48 @@ class EventListener extends BaseListener implements SubscriberInterface
 	{
 		$this->resetDiscountAmounts($event);
 
+		$flat        = [];
+		$percentages = [];
+
 		foreach ($event->getOrder()->discounts as $discount) {
 			if ($discount->percentage) {
-				foreach ($discount->items as $item) {
-					$amount                = round($item->basePrice * ($discount->percentage / 100), 2);
-					$item->discount       += $amount;
-					$discount->amount     += $amount;
-				}
+				$percentages[] = $discount;
+			} else {
+				$flat[] = $discount;
 			}
-			else {
-				$totalBasePrice = 0;
-				foreach($discount->items as $item) {
-					$totalBasePrice += $item->basePrice;
-				}
+		}
 
-				if ($totalBasePrice === 0 ) {
-					continue;
-				}
+		foreach ($flat as $discount) {
+			$totalBasePrice = 0;
+			foreach($discount->items as $item) {
+				$totalBasePrice += $item->basePrice;
+			}
 
-				$prorateHelper = $this->get('helper.prorate')
-					->setGetBasisPercentage(
-						function($item) use ($totalBasePrice)
-					 	{
-					 		return $item->basePrice / $totalBasePrice;
-					 	}
-					 )
-					->setAssignProrateAmount(
-						function($item, $proratedValue)
-						{
-							$item->discount += round($proratedValue, 2);
-						}
-					);
-				$prorateHelper->prorateValue($discount->amount, $discount->items->all());
+			if ($totalBasePrice === 0 ) {
+				continue;
+			}
+
+			$prorateHelper = $this->get('helper.prorate')
+				->setGetBasisPercentage(
+					function($item) use ($totalBasePrice)
+					{
+						return $item->basePrice / $totalBasePrice;
+					}
+				)
+				->setAssignProrateAmount(
+					function($item, $proratedValue)
+					{
+						$item->discount += round($proratedValue, 2);
+					}
+				);
+			$prorateHelper->prorateValue($discount->amount, $discount->items->all());
+		}
+
+		foreach ($percentages as $discount) {
+			foreach ($discount->items as $item) {
+				$amount                = round($item->getDiscountedPrice() * ($discount->percentage / 100), 2);
+				$item->discount       += $amount;
+				$discount->amount     += $amount;
 			}
 		}
 	}

--- a/src/Order/Entity/Item/Collection.php
+++ b/src/Order/Entity/Item/Collection.php
@@ -51,6 +51,28 @@ class Collection extends BaseCollection
 		return $return;
 	}
 
+	public function getTotalDiscountedPrice()
+	{
+		$price = 0;
+
+		foreach ($this->all() as $item) {
+			$price += $item->getDiscountedPrice();
+		}
+
+		return $price;
+	}
+
+	public function getTotalNetPrice()
+	{
+		$net = 0;
+
+		foreach ($this->all() as $item) {
+			$net += $item->net;
+		}
+
+		return $net;
+	}
+
 	public function getTotalTax()
 	{
 		$tax = 0;

--- a/src/Order/Entity/Item/EventListener.php
+++ b/src/Order/Entity/Item/EventListener.php
@@ -217,8 +217,8 @@ class EventListener implements SubscriberInterface
 		$item->gross    = $adjustedGross;
 		$item->tax      = $this->_calculateInclusiveTax($item->gross, $item->taxRate);
 		$item->net      = round($item->gross - $item->tax, 2);
-		$item->gross    = round($item->gross);
-		$item->discount = round($item->discount);
+		$item->gross    = round($item->gross, 2);
+		$item->discount = round($item->discount, 2);
 	}
 
 	protected function _calculateInclusiveTax($amount, $rate)

--- a/src/Order/Entity/Item/EventListener.php
+++ b/src/Order/Entity/Item/EventListener.php
@@ -26,21 +26,21 @@ class EventListener implements SubscriberInterface
 	{
 		return array(
 			OrderEvents::ENTITY_CREATE => array(
-				array('setDefaultActualPrice'),
-				array('setBasePrice', -100),
-				array('calculateTax', -200),
-				array('setDefaultStatus'),
+				['setDefaultActualPrice'],
+				['setBasePrice', -100],
+				['calculateTax', -200],
+				['setDefaultStatus'],
 			),
 			OrderEvents::CREATE_VALIDATE => array(
-				array('checkItemSet')
+				['checkItemSet']
 			),
 			OrderEvents::ASSEMBLER_UPDATE => array(
-				array('setDefaultActualPrice'),
-				array('setBasePrice', -100),
-				array('calculateAllItemsTax', -200),
+				['setDefaultActualPrice'],
+				['setBasePrice', -100],
+				['calculateAllItemsTax', -200],
 			),
 			OrderEvents::STATUS_CHANGE => array(
-				array('updateStatus'),
+				['updateStatus'],
 			),
 		);
 	}
@@ -214,10 +214,11 @@ class EventListener implements SubscriberInterface
 		$adjustedGross += $adjustedGross * ($item->taxRate / 100);
 
 		// Gross is the product gross - discount
-		$item->gross = $adjustedGross;
-		$item->tax   = $this->_calculateInclusiveTax($item->gross, $item->taxRate);
-		$item->net   = round($item->gross - $item->tax, 2);
-		$item->gross = round($item->gross, 2);
+		$item->gross    = $adjustedGross;
+		$item->tax      = $this->_calculateInclusiveTax($item->gross, $item->taxRate);
+		$item->net      = round($item->gross - $item->tax, 2);
+		$item->gross    = round($item->gross);
+		$item->discount = round($item->discount);
 	}
 
 	protected function _calculateInclusiveTax($amount, $rate)

--- a/src/Order/Entity/Item/EventListener.php
+++ b/src/Order/Entity/Item/EventListener.php
@@ -28,7 +28,7 @@ class EventListener implements SubscriberInterface
 			OrderEvents::ENTITY_CREATE => array(
 				['setDefaultActualPrice'],
 				['setBasePrice', -100],
-				['calculateTax', -200],
+				['calculateTax', -300],
 				['setDefaultStatus'],
 			),
 			OrderEvents::CREATE_VALIDATE => array(
@@ -37,7 +37,7 @@ class EventListener implements SubscriberInterface
 			OrderEvents::ASSEMBLER_UPDATE => array(
 				['setDefaultActualPrice'],
 				['setBasePrice', -100],
-				['calculateAllItemsTax', -200],
+				['calculateAllItemsTax', -300],
 			),
 			OrderEvents::STATUS_CHANGE => array(
 				['updateStatus'],

--- a/src/Order/Entity/Item/EventListener.php
+++ b/src/Order/Entity/Item/EventListener.php
@@ -214,9 +214,10 @@ class EventListener implements SubscriberInterface
 		$adjustedGross += $adjustedGross * ($item->taxRate / 100);
 
 		// Gross is the product gross - discount
-		$item->gross = round($adjustedGross, 2);
+		$item->gross = $adjustedGross;
 		$item->tax   = $this->_calculateInclusiveTax($item->gross, $item->taxRate);
 		$item->net   = round($item->gross - $item->tax, 2);
+		$item->gross = round($item->gross, 2);
 	}
 
 	protected function _calculateInclusiveTax($amount, $rate)

--- a/src/Order/Entity/Item/Item.php
+++ b/src/Order/Entity/Item/Item.php
@@ -25,16 +25,17 @@ class Item implements EntityInterface, RecordInterface
 	public $authorship;
 	public $status;
 
-	public $listPrice      = 0; // Retail price of the item as advertised
-	public $actualPrice    = 0; // Same as list price unless it was overriden
-	public $basePrice      = 0; // Price of the item for this order (before discounts) (actual price with or without tax, as appropriate)
-	public $net            = 0; // Net amount, calculated on discounted price
-	public $discount       = 0; // Discount amount for this item
-	public $tax            = 0; // Tax amount for this item
-	public $gross          = 0; // Gross amount paid for this item (after discounts)
-	public $rrp            = 0; // Recommended retail price of the item at time of purchase
-	public $taxRate        = 0; // Tax rate for this item as used on this order
-	public $productTaxRate = 0; // Tax rate of the product (regardless of tax actually being paid)
+	public $listPrice          = 0; // Retail price of the item as advertised
+	public $actualPrice        = 0; // Same as list price unless it was overriden
+	public $discountedPrice    = 0; // Actual price minus discounts
+	public $basePrice          = 0; // Price of the item for this order (before discounts) (actual price with or without tax, as appropriate)
+	public $net                = 0; // Net amount, calculated on discounted price
+	public $discount           = 0; // Discount amount for this item
+	public $tax                = 0; // Tax amount for this item
+	public $gross              = 0; // Gross amount paid for this item (after discounts)
+	public $rrp                = 0; // Recommended retail price of the item at time of purchase
+	public $taxRate            = 0; // Tax rate for this item as used on this order
+	public $productTaxRate     = 0; // Tax rate of the product (regardless of tax actually being paid)
 	public $taxStrategy;
 
 	public $productID;
@@ -150,6 +151,11 @@ class Item implements EntityInterface, RecordInterface
 		}
 
 		return round($this->listPrice - $this->discount - $this->net, 2);
+	}
+
+	public function getDiscountedPrice()
+	{
+		return $this->actualPrice - $this->discount;
 	}
 
 	/**

--- a/src/Order/Entity/Item/Item.php
+++ b/src/Order/Entity/Item/Item.php
@@ -27,7 +27,6 @@ class Item implements EntityInterface, RecordInterface
 
 	public $listPrice          = 0; // Retail price of the item as advertised
 	public $actualPrice        = 0; // Same as list price unless it was overriden
-	public $discountedPrice    = 0; // Actual price minus discounts
 	public $basePrice          = 0; // Price of the item for this order (before discounts) (actual price with or without tax, as appropriate)
 	public $net                = 0; // Net amount, calculated on discounted price
 	public $discount           = 0; // Discount amount for this item

--- a/src/Order/Entity/Item/Row.php
+++ b/src/Order/Entity/Item/Row.php
@@ -66,7 +66,7 @@ class Row implements \IteratorAggregate, \Countable
 		if ($this->count() < 1) {
 			throw new \BadMethodCallException(sprintf(
 				'Cannot sum `%s` property for item row: no items have been set',
-				$property
+				$name
 			));
 		}
 

--- a/src/Order/EventListener/TotalsListener.php
+++ b/src/Order/EventListener/TotalsListener.php
@@ -34,11 +34,11 @@ class TotalsListener extends BaseListener implements SubscriberInterface
 	{
 		return array(
 			OrderEvents::CREATE_START => array(
-				array('calculateShippingTax'),
+				array('calculateShippingTax', -400),
 				array('setTotals', -900),
 			),
 			OrderEvents::ASSEMBLER_UPDATE => array(
-				array('calculateShippingTax'),
+				array('calculateShippingTax', -400),
 				array('setTotals', -900),
 			),
 		);

--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -92,7 +92,7 @@ class Product implements Price\PricedInterface
 			return $this->_entities[$var];
 		}
 
-		throw new \InvalidArgumentException(sprintf('Order entity `%s` does not exist', $var));
+		throw new \InvalidArgumentException(sprintf('Product entity `%s` does not exist', $var));
 
 	}
 
@@ -119,7 +119,7 @@ class Product implements Price\PricedInterface
 	public function addEntity($name, Unit\LoaderInterface $loader)
 	{
 		if (array_key_exists($name, $this->_entities)) {
-			throw new \InvalidArgumentException(sprintf('Order entity already exists with name `%s`', $name));
+			throw new \InvalidArgumentException(sprintf('Product entity already exists with name `%s`', $name));
 		}
 
 		$this->_entities[$name] = new Unit\Collection($this, $loader);


### PR DESCRIPTION
This pull request fixes issues with the way discounts are calculated. Tax deductions were being removed *before* the discount had been applied, resulting in too much tax being reduced.

- Fixed issue in Item\EventListener where tax calculation happens before discounts are applied
- Added `getTotalNetPrice()` method to Item\Collection
- Added `getTotalDiscountedPrice` method to Item\Collection
- Added `getDiscountedPrice` method to Item (returns `$actualPrice - $discount`)
- Adds `type` field to discount order entity
- Calculates discounts of a set value before calculating percentage discounts