### PR TITLE
Amend decoupling migrations

### DIFF
--- a/resources/migrations/_1400150176_DecoupleRefundsFromOrders.php
+++ b/resources/migrations/_1400150176_DecoupleRefundsFromOrders.php
@@ -7,7 +7,7 @@ class _1400150176_DecoupleRefundsFromOrders extends Migration
 	public function up()
 	{
 		$this->run("
-			CREATE TABLE `refund` (
+			CREATE TABLE IF NOT EXISTS `refund` (
 			  `refund_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
 			  `payment_id` int(11) unsigned DEFAULT NULL,
 			  `created_at` int(11) unsigned NOT NULL,
@@ -29,7 +29,7 @@ class _1400150176_DecoupleRefundsFromOrders extends Migration
 		");
 
 		$this->run('
-			INSERT INTO
+			REPLACE INTO
 				`refund` (
 					refund_id,
 					payment_id,

--- a/resources/migrations/_1400150176_DecoupleRefundsFromOrders.php
+++ b/resources/migrations/_1400150176_DecoupleRefundsFromOrders.php
@@ -29,7 +29,7 @@ class _1400150176_DecoupleRefundsFromOrders extends Migration
 		");
 
 		$this->run('
-			REPLACE INTO
+			INSERT IGNORE INTO
 				`refund` (
 					refund_id,
 					payment_id,

--- a/resources/migrations/_1400163185_DecouplePaymentsFromOrders.php
+++ b/resources/migrations/_1400163185_DecouplePaymentsFromOrders.php
@@ -25,7 +25,7 @@ class _1400163185_DecouplePaymentsFromOrders extends Migration
 		");
 
 		$this->run('
-			REPLACE INTO
+			INSERT IGNORE INTO
 				`payment` (
 					payment_id,
 					created_at,

--- a/resources/migrations/_1400163185_DecouplePaymentsFromOrders.php
+++ b/resources/migrations/_1400163185_DecouplePaymentsFromOrders.php
@@ -7,7 +7,7 @@ class _1400163185_DecouplePaymentsFromOrders extends Migration
 	public function up()
 	{
 		$this->run("
-			CREATE TABLE `payment` (
+			CREATE TABLE IF NOT EXISTS `payment` (
 			  `payment_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
 			  `created_at` int(11) unsigned NOT NULL,
 			  `created_by` int(11) unsigned DEFAULT NULL,
@@ -25,7 +25,7 @@ class _1400163185_DecouplePaymentsFromOrders extends Migration
 		");
 
 		$this->run('
-			INSERT INTO
+			REPLACE INTO
 				`payment` (
 					payment_id,
 					created_at,


### PR DESCRIPTION
This PR amends decoupling migrations to only create `refund` and `payment` tables if they do not already exist. This shouldn't be a problem on installations set up since https://github.com/mothership-ec/cog/pull/454 but it might affect older installations if the migrations have run in the wrong order.