### PR TITLE
EU Taxes default configuration

### DIFF
--- a/resources/fixtures/config/tax.yml
+++ b/resources/fixtures/config/tax.yml
@@ -7,6 +7,60 @@ rates:
         - {name: VAT, rate: 20.000}
       shipping-tax:
         - {name: VAT, rate: 20.000}
+  AT:
+    <<: *GB
+  BE:
+    <<: *GB
+  BG:
+    <<: *GB
+  HR:
+    <<: *GB
+  CY:
+    <<: *GB
+  CZ:
+    <<: *GB
+  DK:
+    <<: *GB
+  EE:
+    <<: *GB
+  FI:
+    <<: *GB
+  FR:
+    <<: *GB
+  DE:
+    <<: *GB
+  GR:
+    <<: *GB
+  HU:
+    <<: *GB
+  IE:
+    <<: *GB
+  IT:
+    <<: *GB
+  LV:
+    <<: *GB
+  LT:
+    <<: *GB
+  LU:
+    <<: *GB
+  MT:
+    <<: *GB
+  NL:
+    <<: *GB
+  PL:
+    <<: *GB
+  PT:
+    <<: *GB
+  RO:
+    <<: *GB
+  SK:
+    <<: *GB
+  SI:
+    <<: *GB
+  ES:
+    <<: *GB
+  SE:
+    <<: *GB
   default:
     default:
       voucher-tax:


### PR DESCRIPTION
This adds EU VAT to the default config generated by Mothership. This puts it in line with UK taxation out of the box.

Test by removing vendor/ and the tax file and running composer up. The generated tax file should make all EU countries charge VAT.