### PR TITLE
Optimise units

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -423,7 +423,7 @@ class Services implements ServicesInterface
 		$services['product.entity_loaders'] = $services->factory(function($c) {
 			return 	new EntityLoaderCollection([
 				'units'  => new Commerce\Product\Unit\Loader(
-					$c['db.query'],
+					$c['db.query.builder.factory'],
 					$c['locale'],
 					$c['product.price.types'],
 					$c['currency']

--- a/src/Product/Loader.php
+++ b/src/Product/Loader.php
@@ -5,6 +5,7 @@ namespace Message\Mothership\Commerce\Product;
 use Message\Cog\DB\Query;
 use Message\Cog\DB\Result;
 use Message\Cog\DB\Entity\EntityLoaderCollection;
+use Message\Cog\DB\Entity\EntityLoaderInterface;
 
 use Message\Cog\Localisation\Locale;
 use Message\Cog\ValueObject\DateTimeImmutable;
@@ -12,7 +13,7 @@ use Message\Mothership\FileManager\File\Loader as FileLoader;
 use Message\Mothership\Commerce\Product\Image\TypeCollection as ImageTypes;
 use Message\Mothership\Commerce\Product\Tax\Strategy\TaxStrategyInterface;
 
-class Loader
+class Loader implements EntityLoaderInterface
 {
 	/**
 	 * @var Query

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -149,14 +149,14 @@ class Loader implements ProductEntityLoaderInterface
 		return $units;
 	}
 
-	public function includeInvisible($bool)
+	public function includeInvisible($bool = true)
 	{
 		$this->_loadInvisible = $bool;
 
 		return $this;
 	}
 
-	public function includeOutOfStock($bool)
+	public function includeOutOfStock($bool = true)
 	{
 		$this->_loadOutOfStock = $bool;
 

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -90,7 +90,7 @@ class Loader implements ProductEntityLoaderInterface
 			$unitID = [$unitID];
 		}
 
-		$this->_queryBuilder->where('product_unit.unit_id IN (?ji)', $unitID);
+		$this->_queryBuilder->where('product_unit.unit_id IN (?ji)', [$unitID]);
 
 		return $this->_loadFromQuery($product);
 	}
@@ -116,7 +116,7 @@ class Loader implements ProductEntityLoaderInterface
 
 		$this->_buildQuery();
 
-		$this->_queryBuilder->where('product_unit.barcode IN (?js)', $barcode);
+		$this->_queryBuilder->where('product_unit.barcode IN (?js)', [$barcode]);
 
 		return $this->_loadFromQuery();
 	}
@@ -230,6 +230,10 @@ class Loader implements ProductEntityLoaderInterface
 
 		if (!$this->_loadInvisible) {
 			$this->_queryBuilder->where('product_unit.visible = ?i', [0]);
+		}
+
+		if (!$this->_loadOutOfStock) {
+			$this->_queryBuilder->where('product_unit_stock.stock > 0');
 		}
 	}
 

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -268,6 +268,7 @@ class Loader implements ProductEntityLoaderInterface
 				$unit->barcode     = $row->barcode;
 				$unit->weight      = $row->weight;
 				$unit->supplierRef = $row->supplierRef;
+				$unit->revisionID  = $unit->revisionID ?: 1;
 
 				$unit->setSKU($row->sku);
 				$unit->setVisible((bool) $row->visible);

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -2,23 +2,28 @@
 
 namespace Message\Mothership\Commerce\Product\Unit;
 
-use Message\Mothership\Commerce\Product\Unit\LoaderInterface;
 use Message\Mothership\Commerce\Product\Product;
 use Message\Mothership\Commerce\Product\ProductEntityLoaderInterface;
 use Message\Mothership\Commerce\Product\Loader as ProductLoader;
 use Message\Cog\Localisation\Locale;
 use Message\Cog\ValueObject\DateTimeImmutable;
 
-use Message\Cog\DB\Query;
+use Message\Cog\DB\Entity\EntityLoaderCollection;
+use Message\Cog\DB;
 use Message\Cog\DB\Result;
 
 
 class Loader implements ProductEntityLoaderInterface
 {
 	/**
-	 * @var \Message\Cog\DB\Query
+	 * @var \Message\Cog\DB\QueryBuilderFactory
 	 */
-	protected $_query;
+	protected $_queryBuilderFactory;
+
+	/**
+	 * @var \Message\Cog\DB\QueryBuilder
+	 */
+	protected $_queryBuilder;
 
 	/**
 	 * @var \Message\Cog\Localisation\Locale
@@ -38,19 +43,15 @@ class Loader implements ProductEntityLoaderInterface
 
 	protected $_returnArray = false;
 
-	/**
-	 * Load depencancies
-	 *
-	 * @param Query  $query  Query Object
-	 * @param Locale $locale Locale Object
-	 * @param array $prices
-	 */
-	public function __construct(Query $query, Locale $locale, array $prices, $defaultCurrency)
+	private $_entityLoaderCollection;
+
+	public function __construct(DB\QueryBuilderFactory $queryBuilderFactory, Locale $locale, array $prices, $defaultCurrency)
 	{
 		$this->_defaultCurrency = $defaultCurrency;
-		$this->_query   = $query;
+		$this->_queryBuilderFactory   = $queryBuilderFactory;
 		$this->_locale  = $locale;
 		$this->_prices  = $prices;
+		$this->_entityLoaderCollection = new EntityLoaderCollection();
 	}
 
 	public function setProductLoader(ProductLoader $loader)
@@ -58,6 +59,7 @@ class Loader implements ProductEntityLoaderInterface
 		// @todo this should be set to product loader's include deleted flag
 		$loader->includeDeleted(true);
 		$this->_productLoader = $loader;
+		$this->_entityLoaderCollection->add('product', $this->_productLoader);
 	}
 
 	/**
@@ -69,24 +71,28 @@ class Loader implements ProductEntityLoaderInterface
 	 */
 	public function getByProduct(Product $product)
 	{
-		$result = $this->_query->run('
-			SELECT
-				unit_id
-			FROM
-				product_unit
-			WHERE
-				product_id = ?i
-		', 	array(
-				$product->id
-			)
-		);
+		$this->_buildQuery();
 
-		return count($result) ? $this->_load($result->flatten(), true, $product) : false;
+		$this->_returnArray = true;
+
+		$this->_queryBuilder->where('product_unit.product_id = ?i', [$product->id]);
+
+		return $this->_loadFromQuery($product);
 	}
 
 	public function getByID($unitID, $revisionID = null, Product $product = null)
 	{
-		return $this->_load($unitID, false, $product, $revisionID);
+		$this->_buildQuery($revisionID);
+
+		$this->_returnArray = is_array($unitID);
+
+		if (!is_array($unitID)) {
+			$unitID = [$unitID];
+		}
+
+		$this->_queryBuilder->where('product_unit.unit_id IN (?ji)', $unitID);
+
+		return $this->_loadFromQuery($product);
 	}
 
 	/**
@@ -102,22 +108,17 @@ class Loader implements ProductEntityLoaderInterface
 	 */
 	public function getByBarcode($barcode)
 	{
-		$alwaysReturnArray = is_array($barcode);
+		$this->_returnArray = is_array($barcode);
 
 		if (!is_array($barcode)) {
-			$barcode = array($barcode);
+			$barcode = [$barcode];
 		}
 
-		$result = $this->_query->run('
-			SELECT
-				unit_id
-			FROM
-				product_unit
-			WHERE
-				barcode IN (?js)
-		', array($barcode));
+		$this->_buildQuery();
 
-		return count($result) ? $this->_load($result->flatten(), $alwaysReturnArray) : false;
+		$this->_queryBuilder->where('product_unit.barcode IN (?js)', $barcode);
+
+		return $this->_loadFromQuery();
 	}
 
 	/**
@@ -129,62 +130,26 @@ class Loader implements ProductEntityLoaderInterface
 	{
 		if ($currency === null) {
 			$currency = $this->_defaultCurrency;
-		} 
+		}
 
-		$result = $this->_query->run('
-			SELECT rrp.unit_id AS unit_id FROM
-				(SELECT
-					product_unit.unit_id      AS unit_id,
-					product_price.type        AS type,
-					product_price.currency_id AS currency_id,
-					IFNULL(
-						product_unit_price.price, product_price.price
-					)     					  AS price
-				FROM
-					product_price
-				JOIN
-					product_unit ON (product_price.product_id = product_unit.product_id)
-				LEFT JOIN
-					product_unit_price
-				ON (
-					product_unit.unit_id = product_unit_price.unit_id
-				AND
-					product_price.type = product_unit_price.type
-				AND
-					product_price.currency_id = product_unit_price.currency_id
-				)
-				WHERE product_price.type = \'rrp\') AS rrp 
-			JOIN
-				(SELECT
-					product_unit.unit_id      AS unit_id,
-					product_price.type        AS type,
-					product_price.currency_id AS currency_id,
-					IFNULL(
-						product_unit_price.price, product_price.price
-					)     					  AS price
-				FROM
-					product_price
-				JOIN
-					product_unit ON (product_price.product_id = product_unit.product_id)
-				LEFT JOIN
-					product_unit_price
-				ON (
-					product_unit.unit_id = product_unit_price.unit_id
-				AND
-					product_price.type = product_unit_price.type
-				AND
-					product_price.currency_id = product_unit_price.currency_id
-				)
-				WHERE product_price.type = \'retail\') AS retail
-			ON retail.unit_id = rrp.unit_id 
-			AND rrp.currency_id = retail.currency_id
-			AND (rrp.price - retail.price) > 0
-			AND rrp.currency_id = :currency?s;
-		', [
-			'currency' => $currency
-		]);
+		$saleQuery = $this->_queryBuilderFactory
+			->getQueryBuilder()
+			->select('rrp.unit_id AS unit_id')
+			->from('rrp', $this->_getPriceQuery('rrp'))
+			->join('retail', '
+				retail.unit_id = rrp.unit_id AND
+				rrp.currency_id = retail.currency_id AND
+				(rrp.price - retail.price) > 0 AND
+				rrp.currency_id = :currency?s
+			', $this->_getPriceQuery('retail'))
+			->addParams(['currency' => $currency])
+		;
 
-		return count($result) ? $this->_load($result->flatten(), true) : [];
+		$this->_returnArray = true;
+		$this->_buildQuery();
+		$this->_queryBuilder->where('product_unit.unit_id IN (?q)', $saleQuery);
+
+		return $this->_loadFromQuery();
 	}
 
 	public function includeInvisible($bool)
@@ -201,271 +166,158 @@ class Loader implements ProductEntityLoaderInterface
 		return $this;
 	}
 
-	/**
-	 * @param int | array $unitIDs         $unitIDs Array or single untiID to load
-	 * @param bool $alwaysReturnArray
-	 * @param Product $product             $product Product associated to the product
-	 * @param int | null $revisionID
-	 * @throws \RuntimeException
-	 *
-	 * @return array|bool|mixed             Array of, or singular Unit object
-	 */
-	protected function _load($unitIDs, $alwaysReturnArray = false, Product $product = null, $revisionID = null)
+	private function _buildQuery($revisionID = null)
 	{
-		// Load the data for the units
-		$result = $this->_loadUnits($unitIDs, $revisionID);
-		// Load stock levels
-		$stock = $this->_loadStock($unitIDs);
-		// Load the prices
-		$prices = $this->_loadPrices($unitIDs);
-		// Load the options
-		$options = $this->_loadOptions($unitIDs, $revisionID);
-		// Bind the results to the Unit Object
-		$units = $result->bindTo(
-			'Message\\Mothership\\Commerce\\Product\\Unit\\Unit',
-			[
-				$this->_locale,
-				$this->_prices,
-				$this->_defaultCurrency
-			]
-		);
+		$getRevision = $revisionID ?
+			$this->_queryBuilderFactory->getQueryBuilder()
+				->select(':revisionID?i AS revisionID')
+				->from('product_unit_info')
+				->addParams(['revisionID' => $revisionID])
+				->groupBy('revisionID')
+			:
+			$this->_queryBuilderFactory->getQueryBuilder()
+				->select('IFNULL(MAX(revision_id), 1)')
+				->from('info', 'product_unit_info')
+				->where('info.unit_id = product_unit.unit_id')
+				->groupBy('unit_id')
+		;
 
-		if (0 === count($result)) {
-			return $alwaysReturnArray ? [] : false;
-		}
-		foreach ($result as $key => $data) {
+		$this->_queryBuilder = $this->_queryBuilderFactory->getQueryBuilder()
+			->select([
+				// Unit info
+				'product_unit.product_id    AS productID',
+				'product_unit.unit_id      	AS id',
+				'product_unit.weight_grams 	AS weight',
+				'product_unit_info.sku     	AS sku',
+				'product_unit.barcode      	AS barcode',
+				'product_unit.visible      	AS visible',
+				'product_unit.created_at   	AS createdAt',
+				'product_unit.created_by   	AS createdBy',
+				'product_unit.updated_at   	AS updatedAt',
+				'product_unit.updated_by   	AS updatedBy',
+				'product_unit.deleted_at   	AS deletedAt',
+				'product_unit.deleted_by   	AS deletedBy',
+				'product_unit.supplier_ref 	AS supplierRef',
+				'IFNULL(product_unit_info.revision_id,1) AS revisionID',
+				'product_unit_info.sku      AS sku',
 
-			// Hide units which are not visible
-			if (!$this->_loadInvisible && !$data->visible) {
-				unset($units[$key]);
-				continue;
-			}
-			// Save stock units
-			foreach ($stock as $values) {
-				if ($values->id == $data->id) {
-					$units[$key]->stock[$values->location] = $values->stock;
-				}
-			}
+				// Stock
+				'product_unit_stock.stock    AS stock',
+				'product_unit_stock.location AS stockLocation',
 
-			// Save unit options
-			foreach ($options as $option) {
-				if ($option->id == $data->id) {
-					$units[$key]->options[$option->name] = $option->value;
-				}
-			}
+				// Prices
+				'product_price.type AS priceType',
+				'product_price.currency_id AS currencyID',
+				'IFNULL(product_unit_price.price, product_price.price) AS price',
 
-			// Remove items that are out of stock if needed
-			if (!$this->_loadOutOfStock && array_sum($units[$key]->stock) == 0) {
-				unset($units[$key]);
-				continue;
-			}
-
-			// Save prices to unit
-			foreach ($prices as $price) {
-				if ($price->id == $data->id) {
-					$units[$key]->price[$price->type]->setPrice($price->currencyID, (float) $price->price, $this->_locale);
-				}
-			}
-
-			// Set Authorship details
-			$units[$key]->authorship->create(new DateTimeImmutable(date('c',$data->createdAt)), $data->createdBy);
-			$units[$key]->visible = (bool)$data->visible;
-
-			if ($data->updatedAt) {
-				$units[$key]->authorship->update(new DateTimeImmutable(date('c',$data->updatedAt)), $data->updatedBy);
-			}
-
-			if ($data->deletedAt) {
-				$units[$key]->authorship->delete(new DateTimeImmutable(date('c',$data->deletedAt)), $data->deletedBy);
-			}
-
-			if ($product) {
-				$units[$key]->product = $product;
-			}
-			else {
-				if (!$this->_productLoader) {
-					throw new \RuntimeException('Cannot load product on unit(s) without a product loader instance');
-				}
-
-				$units[$key]->product = $this->_productLoader->getByID($data->product_id);
-			}
-
-			if (is_null($units[$key]->weight)) {
-				$units[$key]->weight = $units[$key]->product->weight;
-			}
-
-		}
-
-		// Reload the array to put the unitID as the key
-		$ordered = array();
-		foreach ($units as $unit) {
-			$ordered[$unit->id] = $unit;
-		}
-
-		return $alwaysReturnArray  ? $ordered : reset($ordered);
-	}
-
-	/**
-	 * Load the options for the given units
-	 *
-	 * @param  int|array $unitIDs UnitIDs to load options for
-	 *
-	 * @return Result 			  DB Result object
-	 */
-	protected function _loadOptions($unitIDs, $revisionID = null)
-	{
-		$getRevision = ' IFNULL(MAX(product_unit_info.revision_id),1) ';
-		if ($revisionID) {
-			$getRevision = $revisionID;
-		}
-
-		return $this->_query->run(
-			'SELECT
-				product_unit_option.unit_id      AS id,
-				product_unit_option.option_name  AS name,
-				product_unit_option.option_value AS value
-			FROM
-				product_unit_option
-			LEFT JOIN
-				product_unit_info ON (
-					product_unit_info.unit_id = product_unit_option.unit_id
-					AND product_unit_option.revision_id = (
-						SELECT
-							'.$getRevision.'
-						FROM
-							product_unit_info AS info
-						WHERE
-							info.unit_id = product_unit_option.unit_id
-						GROUP BY unit_id
-					)
-				)
-			WHERE
-				product_unit_option.unit_id IN (:unitIDs?ij)
-				'.(!is_null($revisionID) ? ' AND product_unit_option.revision_id = '.$getRevision.' ' : ''),
-			array(
-				'unitIDs' => (array) $unitIDs,
-			)
-		);
-	}
-
-	/**
-	 * Load prices for the gievn units for each type. If there is no unit level
-	 * specific pricing then it will use the Product price instead
-	 *
-	 * @param  int|array $unitIDs UnitIDs to load
-	 *
-	 * @return Result 			  DB Result object
-	 */
-	protected function _loadPrices($unitIDs)
-	{
-		return $this->_query->run(
-			'SELECT
-				product_unit.unit_id      AS id,
-				product_price.type        AS type,
-				product_price.currency_id AS currencyID,
-				IFNULL(
-					product_unit_price.price, product_price.price
-				)     					  AS price
-			FROM
-				product_price
-			JOIN
-				product_unit ON (product_price.product_id = product_unit.product_id)
-			LEFT JOIN
-				product_unit_price
-			ON (
-				product_unit.unit_id = product_unit_price.unit_id
-			AND
-				product_price.type = product_unit_price.type
-			AND
+				// Options
+				'product_unit_option.option_name  AS optionName',
+				'product_unit_option.option_value AS optionValue',
+			])
+			->from('product_unit')
+			->leftJoin('product_unit_info', '
+				product_unit_info.unit_id = product_unit.unit_id AND
+				revision_id = (:revisionID?q)
+			')
+			->leftJoin('product_unit_stock', 'product_unit.unit_id = product_unit_stock.unit_id')
+			->leftJoin('product_price', 'product_unit.product_id = product_price.product_id')
+			->leftJoin('product_unit_price', '
+				product_unit.unit_id = product_unit_price.unit_id AND
+				product_price.type = product_unit_price.type AND
 				product_price.currency_id = product_unit_price.currency_id
-			)
-			WHERE
-				product_unit.unit_id IN (?ij)
-		', 	array(
-				(array) $unitIDs,
-			)
-		);
+			')
+			->leftJoin('product_unit_option', 'product_unit_option.unit_id = product_unit.unit_id')
+			->addParams(['revisionID' => $getRevision])
+		;
+
+		if (!$this->_loadInvisible) {
+			$this->_queryBuilder->where('product_unit.visible = ?i', [0]);
+		}
 	}
 
-	/**
-	 * Load the stock levels for each of the given units
-	 *
-	 * @param  int|array $unitIDs UnitIDs to load
-	 *
-	 * @return Result 			  DB Result object
-	 */
-	protected function _loadStock($unitIDs)
+	private function _loadFromQuery(Product $product = null)
 	{
-		return $this->_query->run(
-			'SELECT
-				product_unit_stock.unit_id     	AS id,
-				product_unit_stock.stock       	AS stock,
-				product_unit_stock.location 	AS location
-			FROM
-				product_unit_stock
-			WHERE
-				product_unit_stock.unit_id IN (?ij)
-		', 	array(
-				(array) $unitIDs,
-			)
-		);
-	}
-
-	/**
-	 * Load the attributes for the given unit IDs
-	 *
-	 * @param  int|array $unitIDs UnitIDs to load
-	 *
-	 * @return Result 			  DB Result object
-	 */
-	protected function _loadUnits($unitIDs, $revisionID = null)
-	{
-		$getRevision = '
-			SELECT
-				IFNULL(MAX(revision_id),1)
-			FROM
-				product_unit_info AS info
-			WHERE
-				info.unit_id = product_unit.unit_id
-			GROUP BY
-				unit_id';
-		if ($revisionID) {
-			$getRevision = $revisionID;
+		if (null === $this->_queryBuilder) {
+			throw new \LogicException('Cannot load from query as query has not been built yet');
 		}
 
+		$result = $this->_queryBuilder->run();
 
-		return $this->_query->run(
-			'SELECT
-				product_unit.product_id,
-				product_unit.unit_id      	AS id,
-				product_unit.weight_grams 	AS weight,
-				product_unit_info.sku     	AS sku,
-				product_unit.barcode      	AS barcode,
-				product_unit.visible      	AS visible,
-				product_unit.created_at   	AS createdAt,
-				product_unit.created_by   	AS createdBy,
-				product_unit.updated_at   	AS updatedAt,
-				product_unit.updated_by   	AS updatedBy,
-				product_unit.deleted_at   	AS deletedAt,
-				product_unit.deleted_by   	AS deletedBy,
-				product_unit.supplier_ref 	AS suppliderRef,
-				IFNULL(product_unit_info.revision_id,1) AS revisionID
-			FROM
-				product_unit
-			LEFT JOIN
-				product_unit_info ON (
-					product_unit_info.unit_id = product_unit.unit_id
-					AND revision_id = ('.$getRevision.')
-				)
-			WHERE
-				product_unit.unit_id IN (?ij)
-			AND
-				deleted_at IS NULL
-			GROUP BY
-				product_unit.unit_id',
-			array(
-				(array) $unitIDs,
-			)
-		);
+		$units = [];
+
+		foreach ($result as $row) {
+			if (!array_key_exists($row->id, $units)) {
+				$unit = new UnitProxy(
+					$this->_entityLoaderCollection,
+					$this->_locale,
+					$this->_prices,
+					$this->_defaultCurrency
+				);
+				$unit->id          = $row->id;
+				$unit->barcode     = $row->barcode;
+				$unit->weight      = $row->weight;
+				$unit->supplierRef = $row->supplierRef;
+
+				$unit->setSKU($row->sku);
+				$unit->setVisible((bool) $row->visible);
+
+				if ($product) {
+					$unit->setProduct($product);
+				} else {
+					$unit->setProductID($row->productID);
+				}
+
+				$unit->authorship->create(new DateTimeImmutable(date('c', $row->createdAt)), $row->createdBy);
+
+				if ($row->updatedAt) {
+					$unit->authorship->update(new DateTimeImmutable(date('c', $row->updatedAt)), $row->updatedBy);
+				}
+
+				if ($row->deletedAt) {
+					$unit->authorship->delete(new DateTimeImmutable(date('c', $row->deletedAt)), $row->deletedBy);
+				}
+
+				$units[$row->id] = $unit;
+			}
+
+			$unit = $units[$row->id];
+
+			if (!array_key_exists($row->optionName, $unit->options)) {
+				$unit->options[$row->optionName] = $row->optionValue;
+			}
+
+			if (!array_key_exists($row->stockLocation, $unit->stock)) {
+				$unit->stock[$row->stockLocation] = $row->stock;
+			}
+
+			$unit->setPrice($row->price, $row->priceType, $row->currencyID);
+		}
+
+		return $this->_returnArray ? $units : array_shift($units);
+	}
+
+	private function _getPriceQuery($type)
+	{
+		if (!is_string($type)) {
+			throw new \InvalidArgumentException('Price type must be a string, ' . gettype($type) . ' given');
+		}
+
+		return $this->_queryBuilderFactory
+			->getQueryBuilder()
+			->select([
+				'product_unit.unit_id AS unit_id',
+				'product_price.type AS `type`',
+				'product_price.currency_id AS currency_id',
+				'IFNULL (product_unit_price.price, product_price.price) AS price'
+			])
+			->from('product_price')
+			->join('product_unit', 'product_price.product_id = product_unit.product_id)')
+			->leftJoin('product_unit_price', '
+				product_unit.unit_id = product_unit_price.unit_id AND
+				product_price.type = product_unit_price.type AND
+				product_price.currency_id = product_unit_price.currency_id
+			')
+			->where('product_price.type = ?s', [$type])
+			;
 	}
 }

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -62,6 +62,15 @@ class Loader implements ProductEntityLoaderInterface
 		$this->_entityLoaderCollection->add('product', $this->_productLoader);
 	}
 
+	public function getAll()
+	{
+		$this->_buildQuery();
+
+		$this->_returnArray = true;
+
+		return $this->_loadFromQuery();
+	}
+
 	/**
 	 * Load all the units for a given Product object
 	 *

--- a/src/Product/Unit/Unit.php
+++ b/src/Product/Unit/Unit.php
@@ -52,6 +52,15 @@ class Unit implements PricedInterface
 		}
     }
 
+	public function __set($name, $val)
+	{
+		if ($name === 'product') {
+			$this->setProduct($val);
+		} else {
+			$this->{$name} = $val;
+		}
+	}
+
 	public function setOption($type, $value)
 	{
 		$this->options[$type] = $value;

--- a/src/Product/Unit/Unit.php
+++ b/src/Product/Unit/Unit.php
@@ -30,7 +30,7 @@ class Unit implements PricedInterface
 
 	);
 
-	private $_product;
+	protected $_product;
 
 	protected $_locale;
 	protected $_defaultCurrency;

--- a/src/Product/Unit/Unit.php
+++ b/src/Product/Unit/Unit.php
@@ -30,7 +30,7 @@ class Unit implements PricedInterface
 
 	);
 
-	public $product;
+	private $_product;
 
 	protected $_locale;
 	protected $_defaultCurrency;
@@ -59,6 +59,15 @@ class Unit implements PricedInterface
 		} else {
 			$this->{$name} = $val;
 		}
+	}
+
+	public function __get($name)
+	{
+		if ($name === 'product') {
+			return $this->getProduct();
+		}
+
+		return $this->{$name};
 	}
 
 	public function setOption($type, $value)
@@ -173,7 +182,7 @@ class Unit implements PricedInterface
 
 	public function getProduct()
 	{
-		return $this->product;
+		return $this->_product;
 	}
 
     /**
@@ -185,7 +194,7 @@ class Unit implements PricedInterface
      */
     public function setProduct($product)
     {
-        $this->product = $product;
+        $this->_product = $product;
 
         return $this;
     }

--- a/src/Product/Unit/UnitProxy.php
+++ b/src/Product/Unit/UnitProxy.php
@@ -37,7 +37,7 @@ class UnitProxy extends Unit
 		return $this->_productID;
 	}
 
-	public function setProduct(Product $product)
+	public function setProduct($product)
 	{
 		if (null === $this->_productID) {
 			$this->_productID = $product->id;

--- a/src/Product/Unit/UnitProxy.php
+++ b/src/Product/Unit/UnitProxy.php
@@ -24,9 +24,16 @@ class UnitProxy extends Unit
 
 	public function setProductID($productID)
 	{
-		if (!is_numeric($productID)) {
-			throw new \InvalidArgumentException('Product ID must be numeric');
+		if (!is_numeric($productID) and $productID != (int) $productID) {
+			throw new \InvalidArgumentException('Product ID must be a whole number');
 		}
+
+		$this->_productID = $productID;
+	}
+
+	public function getProductID()
+	{
+		return $this->_productID;
 	}
 
 	public function getProduct()

--- a/src/Product/Unit/UnitProxy.php
+++ b/src/Product/Unit/UnitProxy.php
@@ -4,12 +4,25 @@ namespace Message\Mothership\Commerce\Product\Unit;
 
 use Message\Cog\Localisation\Locale;
 use Message\Cog\DB\Entity\EntityLoaderCollection;
-use Message\Mothership\Commerce\Product\Product;
 
+/**
+ * Class UnitProxy
+ * @package Message\Mothership\Commerce\Product\Unit
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Proxy class for units, so that products can be lazy loaded.
+ */
 class UnitProxy extends Unit
 {
+	/**
+	 * @var EntityLoaderCollection
+	 */
 	private $_loaders;
 
+	/**
+	 * @var int | null
+	 */
 	private $_productID;
 
 	public function __construct(
@@ -23,20 +36,33 @@ class UnitProxy extends Unit
 		parent::__construct($locale, $priceTypes, $defaultCurrency);
 	}
 
+	/**
+	 * Set the product ID so a product can be lazy loaded
+	 *
+	 * @param $productID
+	 */
 	public function setProductID($productID)
 	{
-		if (!is_numeric($productID) and $productID != (int) $productID) {
+		if (!is_numeric($productID) && $productID != (int) $productID) {
 			throw new \InvalidArgumentException('Product ID must be a whole number');
 		}
 
 		$this->_productID = $productID;
 	}
 
+	/**
+	 * Get the product ID
+	 *
+	 * @return int|null
+	 */
 	public function getProductID()
 	{
 		return $this->_productID;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function setProduct($product)
 	{
 		if (null === $this->_productID) {
@@ -46,6 +72,9 @@ class UnitProxy extends Unit
 		return parent::setProduct($product);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function getProduct()
 	{
 		if ($this->_productID && !parent::getProduct() && $this->_loaders->exists('product')) {
@@ -56,6 +85,9 @@ class UnitProxy extends Unit
 		return parent::getProduct();
 	}
 
+	/**
+	 * Drop product on serialization
+	 */
 	public function __sleep()
 	{
 		return array_diff(array_keys(get_object_vars($this)), ['_product']);

--- a/src/Product/Unit/UnitProxy.php
+++ b/src/Product/Unit/UnitProxy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Message\Mothership\Commerce\Product\Unit;
+
+use Message\Cog\Localisation\Locale;
+use Message\Cog\DB\Entity\EntityLoaderCollection;
+
+class UnitProxy extends Unit
+{
+	private $_loaders;
+
+	private $_productID;
+
+	public function __construct(
+		EntityLoaderCollection $loaders,
+		Locale $locale,
+		array $priceTypes,
+		$defaultCurrency
+	)
+	{
+		$this->_loaders = $loaders;
+		parent::__construct($locale, $priceTypes, $defaultCurrency);
+	}
+
+	public function setProductID($productID)
+	{
+		if (!is_numeric($productID)) {
+			throw new \InvalidArgumentException('Product ID must be numeric');
+		}
+	}
+
+	public function getProduct()
+	{
+		if ($this->_productID && !parent::getProduct() && $this->_loaders->exists('product')) {
+			$product = $this->_loaders->get('product')->getByID($this->_productID);
+			$this->setProduct($product);
+		}
+
+		return parent::getProduct();
+	}
+
+}

--- a/src/Product/Unit/UnitProxy.php
+++ b/src/Product/Unit/UnitProxy.php
@@ -4,6 +4,7 @@ namespace Message\Mothership\Commerce\Product\Unit;
 
 use Message\Cog\Localisation\Locale;
 use Message\Cog\DB\Entity\EntityLoaderCollection;
+use Message\Mothership\Commerce\Product\Product;
 
 class UnitProxy extends Unit
 {
@@ -36,6 +37,15 @@ class UnitProxy extends Unit
 		return $this->_productID;
 	}
 
+	public function setProduct(Product $product)
+	{
+		if (null === $this->_productID) {
+			$this->_productID = $product->id;
+		}
+
+		return parent::setProduct($product);
+	}
+
 	public function getProduct()
 	{
 		if ($this->_productID && !parent::getProduct() && $this->_loaders->exists('product')) {
@@ -44,6 +54,11 @@ class UnitProxy extends Unit
 		}
 
 		return parent::getProduct();
+	}
+
+	public function __sleep()
+	{
+		return array_diff(array_keys(get_object_vars($this)), ['_product']);
 	}
 
 }

--- a/src/Report/StockSummary.php
+++ b/src/Report/StockSummary.php
@@ -101,8 +101,8 @@ class StockSummary extends AbstractReport
 			->select('options AS "Options"')
 			->select('stock.stock AS "Stock"')
 			->join("unit","unit.unit_id = stock.unit_id","product_unit")
-			->leftJoin("product","unit.product_id = product.product_id")
-			->leftJoin("unit_options","unit_options.unit_id = unit.unit_id",
+			->join("product","unit.product_id = product.product_id")
+			->join("unit_options","unit_options.unit_id = unit.unit_id",
 				$this->_builderFactory->getQueryBuilder()
 					->select('unit_id')
 					->select('revision_id')


### PR DESCRIPTION
Major refactor of unit loader. The unit loader was running around 4 queries per unit, plus also loading the product and any queries involved with that.

This PR alters the way units are loaded - a row consists of a unique price type and currency, plus option and value. The results are then looped through and the units are built.

I have also introduced a `UnitProxy` class to allow for products to be lazy loaded onto the unit, to make the unit loader more scaleable. 

Requires https://github.com/mothership-ec/cog/pull/461