### PR TITLE
Set default barcode sheet type to `5x13`

### DIFF
--- a/resources/fixtures/config/barcode.yml
+++ b/resources/fixtures/config/barcode.yml
@@ -1,3 +1,3 @@
 file-type: 'png'
 barcode-type: 'code39'
-sheet-type:
+sheet-type: '5x13'


### PR DESCRIPTION
There wasn't a default setting for barcode printing, so the default was 'it breaks', this fixes that