### PR TITLE
Use join instead of left join on stock report

### DIFF
--- a/src/Report/StockSummary.php
+++ b/src/Report/StockSummary.php
@@ -101,8 +101,8 @@ class StockSummary extends AbstractReport
 			->select('options AS "Options"')
 			->select('stock.stock AS "Stock"')
 			->join("unit","unit.unit_id = stock.unit_id","product_unit")
-			->leftJoin("product","unit.product_id = product.product_id")
-			->leftJoin("unit_options","unit_options.unit_id = unit.unit_id",
+			->join("product","unit.product_id = product.product_id")
+			->join("unit_options","unit_options.unit_id = unit.unit_id",
 				$this->_builderFactory->getQueryBuilder()
 					->select('unit_id')
 					->select('revision_id')


### PR DESCRIPTION
This PR alters the stock report to not assume that data is perfectly formed by not using LEFT JOIN. This means that invalid rows are simply ignored, where before the stock report would break as it tried to render the links to the product in the admin panel.