### PR TITLE
Option to include deleted units on UnitLoader

### DIFF
--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -37,6 +37,7 @@ class Loader implements ProductEntityLoaderInterface
 
 	protected $_loadInvisible  = true;
 	protected $_loadOutOfStock = false;
+	protected $_loadDeleted = false;
 
 	protected $_prices;
 	protected $_defaultCurrency;
@@ -172,6 +173,13 @@ class Loader implements ProductEntityLoaderInterface
 		return $this;
 	}
 
+	public function includeDeleted($bool = true)
+	{
+		$this->_loadDeleted = $bool;
+
+		return $this;
+	}
+
 	private function _buildQuery($revisionID = null)
 	{
 		$getRevision = $revisionID ?
@@ -253,6 +261,10 @@ class Loader implements ProductEntityLoaderInterface
 
 		if (!$this->_loadOutOfStock) {
 			$this->_queryBuilder->where('product_unit_stock.stock > 0');
+		}
+
+		if (!$this->_loadDeleted) {
+			$this->_queryBuilder->where('product_unit.deleted_at IS NULL');
 		}
 	}
 


### PR DESCRIPTION
Disabled by default, may be enabled by calling includeDeleted().

Test that the unitLoader only loads deleted units after this method has been called.