### PR TITLE
Order loading order

### DIFF
--- a/src/Controller/Order/Listing.php
+++ b/src/Controller/Order/Listing.php
@@ -4,11 +4,10 @@ namespace Message\Mothership\Commerce\Controller\Order;
 
 use Message\Cog\Controller\Controller;
 
+use Message\Mothership\Commerce\Order\OrderOrder;
 use Message\Mothership\Commerce\Order\Events;
 use Message\Mothership\Commerce\Order\Statuses;
 use Message\Mothership\Commerce\Product\Stock\Location\Location;
-
-use Message\Mothership\Ecommerce\OrderItemStatuses;
 
 use Message\Mothership\ControlPanel\Event\BuildMenuEvent;
 use Message\Mothership\ControlPanel\Event\Dashboard\DashboardEvent;
@@ -136,7 +135,7 @@ class Listing extends Controller
 	{
 		$page = (int) $this->get('request')->get('list-page');
 		return $this->get('pagination')
-			->setAdapter($this->get('order.pagination.adapter'))
+			->setAdapter($this->get('order.pagination.adapter')->orderBy(OrderOrder::CREATED_DATE_REVERSE))
 			->setMaxPerPage(self::DEFAULT_PAGINATION_COUNT)
 			->setCurrentPage($page)
 		;

--- a/src/Order/Loader.php
+++ b/src/Order/Loader.php
@@ -308,6 +308,14 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 		return $this->_load($result->flatten(), true);
 	}
 
+	/**
+	 * Set the order in which the loader should load the orders. Use constants declared within `OrderOrder` class
+	 *
+	 * @param $orderBy
+	 * @throws \InvalidArgumentException
+	 *
+	 * @return Loader
+	 */
 	public function orderBy($orderBy)
 	{
 		if (!is_string($orderBy)) {
@@ -468,6 +476,11 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 		return $returnArray ? $orders : reset($orders);
 	}
 
+	/**
+	 * Return ORDER BY statement for queries based on what `$this->_orderBy` is set to
+	 *
+	 * @return null|string
+	 */
 	private function _getOrderByStatement()
 	{
 		switch ($this->_orderBy) {

--- a/src/Order/Loader.php
+++ b/src/Order/Loader.php
@@ -83,12 +83,17 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 
 	public function getBySlice($offset, $limit)
 	{
-		$qb = $this->_qbFactory->getQueryBuilder();
-
-		$ids = $qb
+		$qb = $this->_qbFactory->getQueryBuilder()
 			->select('order_id')
 			->from('order_summary')
 			->limit($offset, $limit)
+		;
+
+		if ($this->_getOrderByStatement()) {
+			$qb->orderBy($this->_getOrderByStatement());
+		}
+
+		$ids = $qb
 			->getQuery()
 			->run()
 			->flatten()
@@ -220,7 +225,7 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 			->select('order_id')
 			->from('order_summary')
 			->where('status_code IN (?ij)', [$statuses])
-			->orderBy('created_at DESC')
+			->orderBy($this->_getOrderByStatement() ?: 'order_summary.created_at DESC')
 		;
 
 		if ($limitFrom) {
@@ -231,7 +236,7 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 
 		$result = $qb->getQuery()->run();
 
-		$this->_orderBy = 'order_summary.created_at DESC';
+		$this->_orderBy = $this->_orderBy ?: OrderOrder::CREATED_DATE;
 
 		return $this->_load($result->flatten(), true);
 	}
@@ -303,11 +308,22 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 		return $this->_load($result->flatten(), true);
 	}
 
+	public function orderBy($orderBy)
+	{
+		if (!is_string($orderBy)) {
+			throw new \InvalidArgumentException('Order by statement must be a string constant from the `OrderOrder` class, ' . gettype($orderBy) . ' given');
+		}
+
+		$this->_orderBy = $orderBy;
+
+		return $this;
+	}
+
 	protected function _load($ids, $returnArray = false)
 	{
-		$orderBy = $this->_orderBy ? 'ORDER BY ' . $this->_orderBy : '';
+		$orderBy = $this->_getOrderByStatement();
 		$includeDeleted = $this->_includeDeleted ? '' : 'AND deleted_at IS NULL';
-		$this->_orderBy = '';
+		$this->_orderBy = null;
 
 		if (!is_array($ids)) {
 			$ids = (array) $ids;
@@ -352,7 +368,7 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 			' . $includeDeleted .'
 			GROUP BY
 				order_summary.order_id
-			' . ($orderBy) . '
+			' . ($orderBy ? 'ORDER BY ' . $orderBy : '') . '
 		', array($ids));
 		if (0 === count($result)) {
 			return $returnArray ? array() : false;
@@ -450,6 +466,28 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 		});
 
 		return $returnArray ? $orders : reset($orders);
+	}
+
+	private function _getOrderByStatement()
+	{
+		switch ($this->_orderBy) {
+			case OrderOrder::ID :
+				return 'order_summary.order_id ASC';
+			case OrderOrder::ID_REVERSE :
+				return 'order_summary.order_id DESC';
+			case OrderOrder::UPDATED_DATE :
+				return 'order_summary.updated_at ASC';
+			case OrderOrder::UPDATED_DATE_REVERSE :
+				return 'order_summary.updated_at DESC';
+			case OrderOrder::CREATED_DATE :
+				return 'order_summary.created_at ASC';
+			case OrderOrder::CREATED_DATE_REVERSE :
+				return 'order_summary.created_at DESC';
+			case OrderOrder::NONE :
+				return null;
+			default :
+				return null;
+		}
 	}
 
 	/**

--- a/src/Order/OrderOrder.php
+++ b/src/Order/OrderOrder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Message\Mothership\Commerce\Order;
+
+/**
+ * Class OrderOrder
+ * @package Message\Mothership\Commerce\Order
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class of constants for determining the order in which orders will be loaded from the database.
+ * Apologies for the class name but the English language has too many meanings for the word 'order'
+ */
+class OrderOrder
+{
+	const CREATED_DATE         = "commerce.order.order.date.created";
+	const CREATED_DATE_REVERSE = "commerce.order.order.date.created.reverse";
+	const UPDATED_DATE         = "commerce.order.order.date.updated";
+	const UPDATED_DATE_REVERSE = "commerce.order.order.date.updated.reverse";
+	const ID                   = "commerce.order.order.id";
+	const ID_REVERSE           = "commerce.order.order.id.reverse";
+	const NONE                 = "commerce.order.order.none";
+}

--- a/src/Pagination/OrderAdapter.php
+++ b/src/Pagination/OrderAdapter.php
@@ -10,9 +10,18 @@ class OrderAdapter implements AdapterInterface
 	private $_orderLoader;
 	private $_statuses;
 
+	private $_orderBy;
+
 	public function __construct(OrderLoader $orderLoader)
 	{
 		$this->_orderLoader  = $orderLoader;
+	}
+
+	public function orderBy($orderBy)
+	{
+		$this->_orderBy = $orderBy;
+
+		return $this;
 	}
 
 	public function getCount()
@@ -23,6 +32,10 @@ class OrderAdapter implements AdapterInterface
 	public function getSlice($offset, $limit)
 	{
 		$offset = $offset * $limit;
+
+		if ($this->_orderBy) {
+			$this->_orderLoader->orderBy($this->_orderBy);
+		}
 
 		if ($this->_statuses) {
 			return $this->_orderLoader->getByStatus($this->_statuses, $offset, $limit);


### PR DESCRIPTION
'Order' means two things and that is annoying.

This PR allows developers to set the order in which orders are loaded via the order loader. This is done by calling the `orderBy()` method on the order loader. It takes variables that are constants declared in the `OrderOrder` class.

This PR also uses this functionality to reverse the order of orders in the `All Orders` and `Shipped Orders` tabs