### PR TITLE
Improved order search

### DIFF
--- a/resources/view/order/detail/view.html.twig
+++ b/resources/view/order/detail/view.html.twig
@@ -1,6 +1,6 @@
 {% extends 'Message:Mothership:ControlPanel::_templates/left_sidebar' %}
 {% block sidebar %}
-	{{ render(controller('Message:Mothership:Commerce::Controller:Order:OrderDetail#sidebar', { 'orderID': order.id } )) }}
+	{{ render(controller('Message:Mothership:Commerce::Controller:Order:Listing#sidebar')) }}
 {% endblock %}
 {% block main %}
 	<hgroup class="title">

--- a/src/Order/Loader.php
+++ b/src/Order/Loader.php
@@ -341,8 +341,14 @@ class Loader implements Transaction\DeletableRecordLoaderInterface
 
 		$terms = explode(' ', $term);
 
+		array_walk($terms, function (&$term) {
+			$term = trim($term);
+		});
+
+		$terms = array_unique($terms);
+
 		foreach ($terms as $term) {
-			$term = '%' . trim($term) . '%';
+			$term = '%' . $term . '%';
 
 			$queryBuilder->where('(
 				os.user_email LIKE :term?s OR

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -333,6 +333,10 @@ ms.commerce:
         issue-refund: Issue a refund?
         notify-customer: Notify the customer by email?
         password-confirm: Please confirm your account password to continue
+      search:
+        one-result: Showing the only order matching the term "%term%"
+        results: Found %amount% results matching the term "%term%"
+        no-results: No results found matching search term "%term%"
 
     item:
       none: There are no items to view.


### PR DESCRIPTION
This PR adds a `getBySearchTerm()` method to the order loader. This does a fuzzier search of the following fields:

 - Order ID
 - User email address
 - Customer forename
 - Customer surname
 - Address lines 1-4
 - Address country
 - Address postcode
 - Address telephone number
 - Address town
 - Address state (full name, not code)
 - Address country (full name, not code)
 - Discount code
 - Dispatch ID
 - Dispatch code
 - Order note
 - Payment reference

Each word in the search term must match at least one of these fields for the order to be returned

This PR also replaces the 'Back to orders' link in the sidebar when viewing an order with the regular sidebar, and adds translations for flash messages when searching for an order