### PR TITLE
Redundant tax arguments

### DIFF
--- a/src/Product/Product.php
+++ b/src/Product/Product.php
@@ -342,7 +342,7 @@ class Product implements Price\PricedInterface
 	{
 		$currencyID = $currencyID ?: $this->_defaultCurrency;
 
-		return $this->_taxStrategy->getNetPrice($this->getPrice($type, $currencyID), $this->getTaxRates());
+		return $this->_taxStrategy->getNetPrice($this->getPrice($type, $currencyID));
 	}
 
 	/**
@@ -352,7 +352,7 @@ class Product implements Price\PricedInterface
 	{
 		$currencyID = $currencyID ?: $this->_defaultCurrency;
 
-		return $this->_taxStrategy->getNetPrice($this->getPriceFrom($type, $currencyID), $this->getTaxRates());
+		return $this->_taxStrategy->getNetPrice($this->getPriceFrom($type, $currencyID));
 	}
 
 	/**

--- a/src/Product/Tax/Strategy/TaxStrategyInterface.php
+++ b/src/Product/Tax/Strategy/TaxStrategyInterface.php
@@ -16,7 +16,6 @@ interface TaxStrategyInterface
 	 * Gets the net price based on a price and a tax rate
 	 * 
 	 * @param  double                    $price   The price
-	 * @param  TaxRate|TaxRateCollection $taxRate The tax rate to use
 	 * @return double                    The display price
 	 */
 	public function getNetPrice($price);

--- a/src/Product/Unit/Unit.php
+++ b/src/Product/Unit/Unit.php
@@ -107,10 +107,7 @@ class Unit implements PricedInterface
 	{
 		$product = $this->getProduct();
 
-		return $product->getTaxStrategy()->getNetPrice(
-			$this->getPrice($type, $currencyID),
-			$product->getTaxRates()
-		);
+		return $product->getTaxStrategy()->getNetPrice($this->getPrice($type, $currencyID));
 	}
 
 	/**

--- a/tests/Product/Tax/Strategy/ExclusiveTaxStrategyTest.php
+++ b/tests/Product/Tax/Strategy/ExclusiveTaxStrategyTest.php
@@ -19,13 +19,7 @@ class ExclusiveTaxStrategyTest extends \PHPUnit_Framework_TestCase
 		$strategy = new ExclusiveTaxStrategy;
 		$price = 100;
 
-		$this->_taxRate->shouldReceive('getTaxedPrice')
-			->with($price)
-			->zeroOrMoreTimes()
-			->andReturn($price);
-
-
-		$this->assertEquals($price, $strategy->getNetPrice($price, $this->_taxRate));
+		$this->assertEquals($price, $strategy->getNetPrice($price));
 	}
 
 	public function testGetGrossPrice()

--- a/tests/Product/Tax/Strategy/InclusiveTaxStrategyTest.php
+++ b/tests/Product/Tax/Strategy/InclusiveTaxStrategyTest.php
@@ -69,6 +69,6 @@ class InclusiveTaxStrategyTest extends \PHPUnit_Framework_TestCase
 	public function testInvalidPriceException()
 	{
 		$strategy = $this->_strategy;
-		$strategy->getNetPrice('Not a string', $this->_taxRate);
+		$strategy->getNetPrice('Not a number');
 	}
 }

--- a/tests/Product/Tax/Strategy/InclusiveTaxStrategyTest.php
+++ b/tests/Product/Tax/Strategy/InclusiveTaxStrategyTest.php
@@ -38,7 +38,7 @@ class InclusiveTaxStrategyTest extends \PHPUnit_Framework_TestCase
 
 	public function testGetNetPrice()
 	{
-		$this->assertEquals(100, $this->_strategy->getNetPrice(120, $this->_taxRate));
+		$this->assertEquals(100, $this->_strategy->getNetPrice(120));
 	}
 	
 	public function testGetGrossPrice()


### PR DESCRIPTION
`getNetPrice()` on tax strategies only takes one argument of price. There were multiple places including tests where it was being called with a `$taxRate` argument or similar. This alters these calls to not pass the rate.

Test that all price related functionality works, that the specific unit tests pass, and that what I have deleted is correct.