### PR TITLE
Load latest unit revsion

### DIFF
--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -92,7 +92,7 @@ class Loader implements ProductEntityLoaderInterface
 
 	public function getByID($unitID, $revisionID = null, Product $product = null)
 	{
-		if (!is_numeric($revisionID) || $revisionID !== null) {
+		if (!is_numeric($revisionID) && $revisionID !== null) {
 			throw new \InvalidArgumentException('Revision ID must be numeric or null '.gettype($revisionID).' given');
 		}
 

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -93,7 +93,7 @@ class Loader implements ProductEntityLoaderInterface
 	public function getByID($unitID, $revisionID = null, Product $product = null)
 	{
 		if (!is_numeric($revision_id) || $revision_id !== null) {
-			throw new \InvalidArgumentException('Revision ID must be numeric or null %s given' . gettype($revision_id));
+			throw new \InvalidArgumentException('Revision ID must be numeric or null '.gettype($revision_id).' given');
 		}
 
 		$this->_buildQuery($revisionID);

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -92,8 +92,8 @@ class Loader implements ProductEntityLoaderInterface
 
 	public function getByID($unitID, $revisionID = null, Product $product = null)
 	{
-		if (!is_numeric($revision_id) || $revision_id !== null) {
-			throw new \InvalidArgumentException('Revision ID must be numeric or null '.gettype($revision_id).' given');
+		if (!is_numeric($revisionID) || $revisionID !== null) {
+			throw new \InvalidArgumentException('Revision ID must be numeric or null '.gettype($revisionID).' given');
 		}
 
 		$this->_buildQuery($revisionID);


### PR DESCRIPTION
The unit loader was loading revision 1 if no revision given. This is the oldest revision. This updates the unit loader to load the most recent revision instead of the oldest by default, a bug probably introduced with the unit loader refactor.

Test by loading both with a revision and without. Check the correct revision is loaded.