### PR TITLE
Use product real name

### DIFF
--- a/src/Report/AppendQuery/Sales.php
+++ b/src/Report/AppendQuery/Sales.php
@@ -65,7 +65,7 @@ class Sales implements FilterableInterface
 			->select('item.order_id AS "Order_ID"')
 			->select('NULL AS "Return_ID"')
 			->select('item.product_id AS "Product_ID"')
-			->select('item.product_name AS "Product"')
+			->select('product.name AS "Product"')
 			->select('item.options AS "Option"')
 			->select('country AS "Country"')
 			->select('user.forename AS "User_Forename"')

--- a/src/Report/SalesByItem.php
+++ b/src/Report/SalesByItem.php
@@ -121,9 +121,7 @@ class SalesByItem extends AbstractSales
 		$result = [];
 
 		if ($output === "json") {
-
 			foreach ($data as $row) {
-
 				$result[] = [
 					[
 						'v' => (float) $row->UnixDate,
@@ -158,10 +156,9 @@ class SalesByItem extends AbstractSales
 					],
 				];
 			}
+
 			return json_encode($result);
-
 		} else {
-
 			foreach ($data as $row) {
 				$result[] = [
 					$row->Date,
@@ -177,6 +174,7 @@ class SalesByItem extends AbstractSales
 					$row->Gross,
 				];
 			}
+
 			return $result;
 		}
 	}


### PR DESCRIPTION
This change causes sales reports to show the products real name rather than the name it had when the Item was created. Initially it was designed to use the item's name so that what the user was told they'd get when purchasing could be seen. This, however, makes analysing which products are the best sellers really hard if the product name has changed. It's quite easy to think a product is doing much worse than it actually is simply because you're only accounting for one of the names the product has.

This change causes the name displayed to be the current product name.