### PR TITLE
Can no longer make units with no options

### DIFF
--- a/resources/view/product/edit-unit.html.twig
+++ b/resources/view/product/edit-unit.html.twig
@@ -24,27 +24,29 @@
 		</thead>
 		<tbody>
 			{% for unit in units %}
-				<tr>
-					<td>{{ form_widget(form[unit.id]['sku']) }}</td>
-					<td>
-						{{ form_widget(form[unit.id]['options']) }}
-					</td>
-					<td>
-						<div class="multi-inline">
-							<div class="inline">
-									{% for currency, price in form[unit.id].prices.currencies %}
-									<div class="currency-units">
-										<h4>{{ currency }}</h4>
-									    {{ form_widget(price) }}
-									</div>
-									{% endfor %}
+				{% if unit.options | length %}
+					<tr>
+						<td>{{ form_widget(form[unit.id]['sku']) }}</td>
+						<td>
+							{{ form_widget(form[unit.id]['options']) }}
+						</td>
+						<td>
+							<div class="multi-inline">
+								<div class="inline">
+										{% for currency, price in form[unit.id].prices.currencies %}
+										<div class="currency-units">
+											<h4>{{ currency }}</h4>
+											{{ form_widget(price) }}
+										</div>
+										{% endfor %}
+								</div>
 							</div>
-						</div>
-					</td>
-					<td>{{ form_widget(form[unit.id]['weight']) }}</td>
-					<td class="a-center">{{ form_widget(form[unit.id]['visible']) }}</td>
-					<td><a class="button delete small" href="{{ url('ms.commerce.product.unit.delete', {productID: unit.product.id, unitID: unit.id})}}" data-confirm="Are you sure you want to delete this unit?">Delete</a></td>
-				</tr>
+						</td>
+						<td>{{ form_widget(form[unit.id]['weight']) }}</td>
+						<td class="a-center">{{ form_widget(form[unit.id]['visible']) }}</td>
+						<td><a class="button delete small" href="{{ url('ms.commerce.product.unit.delete', {productID: unit.product.id, unitID: unit.id})}}" data-confirm="Are you sure you want to delete this unit?">Delete</a></td>
+					</tr>
+				{% endif %}
 			{% endfor %}
 		</tbody>
 	</table>

--- a/src/Bootstrap/Tasks.php
+++ b/src/Bootstrap/Tasks.php
@@ -21,5 +21,6 @@ class Tasks implements TasksInterface
 
 		$tasks->add(new Product\Barcode\GenerateTask('commerce:barcode:generate'), 'Creates barcode images for all units in the database');
 
+		$tasks->add(new Task\Product\DeleteOptionlessUnits('commerce:delete_optionless_units'), 'Marks units with no options as deleted');
 	}
 }

--- a/src/Constraint/Product/UnitHasOptions.php
+++ b/src/Constraint/Product/UnitHasOptions.php
@@ -4,6 +4,15 @@ namespace Message\Mothership\Commerce\Constraint\Product;
 
 use Symfony\Component\Validator\Constraint;
 
+/**
+ * Class UnitHasOptions
+ * @package Message\Mothership\Commerce\Constraint\Product
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Constraint to be applied when adding units. If a unit has no options the form should invalidate the
+ * data
+ */
 class UnitHasOptions extends Constraint
 {
 	public $message = 'Cannot create unit as it must have at least one option';

--- a/src/Constraint/Product/UnitHasOptions.php
+++ b/src/Constraint/Product/UnitHasOptions.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Message\Mothership\Commerce\Constraint\Product;
+
+use Symfony\Component\Validator\Constraint;
+
+class UnitHasOptions extends Constraint
+{
+	public $message = 'Cannot create unit as it must have at least one option';
+}

--- a/src/Constraint/Product/UnitHasOptionsValidator.php
+++ b/src/Constraint/Product/UnitHasOptionsValidator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Message\Mothership\Commerce\Constraint\Product;
+
+use Symfony\Component\Validator;
+
+class UnitHasOptionsValidator extends Validator\ConstraintValidator
+{
+	public function validate($value, Validator\Constraint $constraint)
+	{
+		if (!$constraint instanceof UnitHasOptions) {
+			throw new \InvalidArgumentException('Constraint must be an instance of `' . __NAMESPACE__ . '\\UnitHasOptions`, `' . get_class($constraint) . '` given');
+		}
+
+		if (!is_array($value)) {
+			throw new \InvalidArgumentException('Value must be an array, ' . gettype($value) . ' given');
+		}
+
+		if (count($value) <= 0) {
+			$this->context->addViolation($constraint->message);
+		}
+	}
+}

--- a/src/Constraint/Product/UnitHasOptionsValidator.php
+++ b/src/Constraint/Product/UnitHasOptionsValidator.php
@@ -4,8 +4,21 @@ namespace Message\Mothership\Commerce\Constraint\Product;
 
 use Symfony\Component\Validator;
 
+/**
+ * Class UnitHasOptionsValidator
+ * @package Message\Mothership\Commerce\Constraint\Product
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class that checks if a unit has options set, and adds an error message if not
+ */
 class UnitHasOptionsValidator extends Validator\ConstraintValidator
 {
+	/**
+	 * {@inheritDoc}
+	 * @throws \InvalidArgumentException       Throws exception if $constraint is not an instance of UnitHasOptions
+	 * @throws \InvalidArgumentException       Throws exception if $value is not an array
+	 */
 	public function validate($value, Validator\Constraint $constraint)
 	{
 		if (!$constraint instanceof UnitHasOptions) {

--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -398,7 +398,7 @@ class Edit extends Controller
 			foreach ($data['units'] as $unitID => $locationArray) {
 				foreach ($locationArray as $location => $stock) {
 					// remove all spaces and tabs and cast stock to int
-					$stock = (int)(preg_replace('/\s+/','',$stock));
+					$stock = (int) (preg_replace('/\s+/','',$stock));
 
 					if ($stock > 0) {
 						$stockManager->increment(

--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -225,10 +225,10 @@ class Edit extends Controller
 		$form->handleRequest();
 
 		if ($form->isValid() && $data = $form->getData()) {
+			de($data);
 			$unit              = $this->get('product.unit');
 			$unit->sku         = $data['sku'];
 			$unit->weight 	   = $data['weight'];
-			// TODO: Where does that 1 come from? -> constant??
 			$unit->revisionID  = 1;
 			$unit->product     = $this->_product;
 

--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -225,7 +225,6 @@ class Edit extends Controller
 		$form->handleRequest();
 
 		if ($form->isValid() && $data = $form->getData()) {
-			de($data);
 			$unit              = $this->get('product.unit');
 			$unit->sku         = $data['sku'];
 			$unit->weight 	   = $data['weight'];

--- a/src/Product/Form/UnitAdd.php
+++ b/src/Product/Form/UnitAdd.php
@@ -66,7 +66,7 @@ class UnitAdd extends AbstractType
 				'allow_add'    => true,
 				'allow_delete' => true,
 				'constraints'  => [
-//					new UnitHasOptions
+					new UnitHasOptions
 				]
 			]
 		);

--- a/src/Product/Form/UnitAdd.php
+++ b/src/Product/Form/UnitAdd.php
@@ -5,9 +5,10 @@ namespace Message\Mothership\Commerce\Product\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Message\Mothership\Commerce\Product\OptionLoader;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Message\Mothership\Commerce\Product\OptionLoader;
 use Message\Mothership\Commerce\Field\OptionType;
+use Message\Mothership\Commerce\Constraint\Product\UnitHasOptions;
 
 class UnitAdd extends AbstractType
 {
@@ -63,7 +64,10 @@ class UnitAdd extends AbstractType
 				'type'         => $optionType,
 				'label'        => 'Options',
 				'allow_add'    => true,
-				'allow_delete' => true
+				'allow_delete' => true,
+				'constraints'  => [
+					new UnitHasOptions
+				]
 			]
 		);
 

--- a/src/Product/Form/UnitAdd.php
+++ b/src/Product/Form/UnitAdd.php
@@ -66,7 +66,7 @@ class UnitAdd extends AbstractType
 				'allow_add'    => true,
 				'allow_delete' => true,
 				'constraints'  => [
-					new UnitHasOptions
+//					new UnitHasOptions
 				]
 			]
 		);

--- a/src/Product/Form/UnitEdit.php
+++ b/src/Product/Form/UnitEdit.php
@@ -31,6 +31,12 @@ class UnitEdit extends AbstractType
 		}
 
 		foreach ($units as $unit) {
+
+			// If a unit has no options, it is broken so we should ignore it
+			if (count($unit->options) <= 0) {
+				continue;
+			}
+
 			$unitForm = $builder->create($unit->id, 'form');
 
 			$unitForm->add('sku', 'text', [
@@ -41,7 +47,7 @@ class UnitEdit extends AbstractType
 
 			// Create options form
 			$optionsForm = $builder->create('options', 'form');
-			foreach($headings as $type => $displayName) {
+			foreach ($headings as $type => $displayName) {
 				$choices = [];
 				foreach ($this->_optionLoader->getByName($type) as $choice) {
 					$choice = trim($choice);

--- a/src/Product/ProductProxy.php
+++ b/src/Product/ProductProxy.php
@@ -142,7 +142,8 @@ class ProductProxy extends Product
 	{
 		$this->_loaders->get('units')
 			->includeOutOfStock(true)
-			->includeInvisible(true);
+			->includeInvisible(true)
+		;
 
 		$this->_load('units');
 	}

--- a/src/Product/Unit/Create.php
+++ b/src/Product/Unit/Create.php
@@ -32,6 +32,10 @@ class Create
 
 	public function create(Unit $unit)
 	{
+		if (count($unit->options === 0)) {
+			throw new \LogicException('Cannot create a unit as it has no options!');
+		}
+
 		$event = new Event($unit);
 		$this->_dispatcher->dispatch(Events::PRODUCT_UNIT_BEFORE_CREATE, $event);
 

--- a/src/Product/Unit/Create.php
+++ b/src/Product/Unit/Create.php
@@ -32,7 +32,7 @@ class Create
 
 	public function create(Unit $unit)
 	{
-		if (count($unit->options === 0)) {
+		if (count($unit->options) === 0) {
 			throw new \LogicException('Cannot create a unit as it has no options!');
 		}
 

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -293,6 +293,7 @@ class Loader implements ProductEntityLoaderInterface
 				$unit->weight      = $row->weight;
 				$unit->supplierRef = $row->supplierRef;
 				$unit->revisionID  = $row->revisionID;
+				$unit->options     = [];
 
 				$unit->setSKU($row->sku);
 				$unit->setVisible((bool) $row->visible);
@@ -318,7 +319,7 @@ class Loader implements ProductEntityLoaderInterface
 
 			$unit = $units[$row->id];
 
-			if (!array_key_exists($row->optionName, $unit->options)) {
+			if ($row->optionName && $row->optionValue && !array_key_exists($row->optionName, $unit->options)) {
 				$unit->options[$row->optionName] = $row->optionValue;
 			}
 

--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -254,7 +254,10 @@ class Loader implements ProductEntityLoaderInterface
 				product_price.type = product_unit_price.type AND
 				product_price.currency_id = product_unit_price.currency_id
 			')
-			->leftJoin('product_unit_option', 'product_unit_option.unit_id = product_unit.unit_id')
+			->leftJoin('product_unit_option', '
+				product_unit_option.unit_id = product_unit.unit_id AND
+				product_unit_option.revision_id = product_unit_info.revision_id
+			')
 		;
 
 		if (!$this->_loadInvisible) {

--- a/src/Task/Product/DeleteOptionlessUnits.php
+++ b/src/Task/Product/DeleteOptionlessUnits.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Message\Mothership\Commerce\Task\Product;
+
+use Message\Cog\Console\Task\Task;
+
+/**
+ * Class DeleteOptionlessUnits
+ * @package Message\Mothership\Commerce\Task\Product
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
+class DeleteOptionlessUnits extends Task
+{
+	public function process()
+	{
+		$units = $this->get('product.unit.loader')
+			->includeInvisible()
+			->includeOutOfStock()
+			->includeDeleted(false)
+			->getAll()
+		;
+
+		$this->writeln('Loaded ' . count($units) . ' units');
+
+		$invalid = [];
+
+		foreach ($units as $unit) {
+			if (count($unit->options) === 0) {
+				$this->writeln('<info>Unit ' . $unit->id . ' has no options, marking for deletion</info>');
+				$invalid[] = $unit;
+			}
+		}
+
+		$this->writeln('<info>Found ' . count($invalid) . ' invalid units</info>');
+
+		foreach ($invalid as $unit) {
+			$this->writeln('<info>Deleting unit ' . $unit->id . '</info>');
+			$this->get('product.unit.delete')->delete($unit);
+			$this->writeln('<info>Unit ' . $unit->id . ' deleted</info>');
+		}
+
+		$this->writeln('<info>Deletion completion</info>');
+	}
+}

--- a/src/Task/Product/DeleteOptionlessUnits.php
+++ b/src/Task/Product/DeleteOptionlessUnits.php
@@ -9,9 +9,15 @@ use Message\Cog\Console\Task\Task;
  * @package Message\Mothership\Commerce\Task\Product
  *
  * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Task for deleting units that have no options assigned to them. It was previously possible to create units
+ * with no options, which would break on the unit edit screen. This task marks any of those units as deleted.
  */
 class DeleteOptionlessUnits extends Task
 {
+	/**
+	 * {@inheritDoc}
+	 */
 	public function process()
 	{
 		$units = $this->get('product.unit.loader')

--- a/src/Task/Product/DeleteOptionlessUnits.php
+++ b/src/Task/Product/DeleteOptionlessUnits.php
@@ -46,6 +46,6 @@ class DeleteOptionlessUnits extends Task
 			$this->writeln('<info>Unit ' . $unit->id . ' deleted</info>');
 		}
 
-		$this->writeln('<info>Deletion completion</info>');
+		$this->writeln('<info>Deletion completed</info>');
 	}
 }

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -28,7 +28,7 @@ ms.commerce:
     button:
       save: Save changes
       create: Create product
-      sku: Add SKU
+      sku: Add unit
       barcodes: Print barcodes
       variant: Add Variant
       back: Back


### PR DESCRIPTION
This PR makes it impossible to create units with no options, as well as providing a task to mark any units that don't have units as deleted.

It does this by:

+ Throwing a logic exception in `Unit\Create` if a unit has no options
+ Adding a `UnitHasOptions` constraint and a matching validator and setting it on the unit create form
+ Removing units with no options from the unit edit form

Also has the following bug fixes:

+ `Unit\Loader` no longer sets units with no options to have the $options set as `['' => null]`, it is now set as an empty array
+ `Unit\Loader` joins with revision ID as well as unit ID, which resolves the issue where sometimes it would appear that unit options hadn't saved in the admin panel
+ Changed `Add SKU` button to say `Add unit`