### PR TITLE
Improvements to unit add form

### DIFF
--- a/resources/view/product/edit-stock.html.twig
+++ b/resources/view/product/edit-stock.html.twig
@@ -22,21 +22,23 @@
 				</thead>
 				<tbody>
 					{% for unit in units %}
-						<tr>
-							<td><span>{{ unit.sku }}</span></td>
-							{% for key, name in headings %}
-								<td>
-								{% if key in unit.options|keys %}
-									{{ unit.getOption(key) }}
-								{% endif %}
-								</td>
-							{% endfor %}
-							{% for location in locations %}
-								<div class="inline">
-									<td>{{ unit.getStockForLocation(location) }} {{ form_widget(form['units'][unit.id][location.name]) }}</td>
-								</div>
-							{% endfor %}
-						</tr>
+						{% if unit.options | length %}
+							<tr>
+								<td><span>{{ unit.sku }}</span></td>
+								{% for key, name in headings %}
+									<td>
+									{% if key in unit.options|keys %}
+										{{ unit.getOption(key) }}
+									{% endif %}
+									</td>
+								{% endfor %}
+								{% for location in locations %}
+									<div class="inline">
+										<td>{{ unit.getStockForLocation(location) }} {{ form_widget(form['units'][unit.id][location.name]) }}</td>
+									</div>
+								{% endfor %}
+							</tr>
+						{% endif %}
 					{% endfor %}
 				</tbody>
 			</table>

--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -494,6 +494,11 @@ class Edit extends Controller
 
 		// Create a nested form for each unit
 		foreach ($this->_units as $id => $unit) {
+
+			if (count($unit->options) <= 0) {
+				continue;
+			}
+
 			$stockForm = $this->get('form')
 				->setName($id)
 				->addOptions(array(

--- a/src/Field/OptionType.php
+++ b/src/Field/OptionType.php
@@ -5,6 +5,7 @@ namespace Message\Mothership\Commerce\Field;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints;
 
 class OptionType extends AbstractType {
 
@@ -56,9 +57,13 @@ class OptionType extends AbstractType {
 				'label'    => ($this->_nameLabel ? $this->_nameLabel : 'Name'),
 				'choices'  => $this->_nameChoice,
 				'required' => true,
-				'attr'     => array(
+				'attr'     => [
 					'data-help-key' => $nameHelpKey,
-				),
+					'placeholder' => "e.g. 'Colour'",
+				],
+				'constraints' => [
+					new Constraints\NotBlank
+				]
 			)
 		);
 		if(count($this->_valueChoice) > 0) {
@@ -67,19 +72,26 @@ class OptionType extends AbstractType {
 					'label'    => ($this->_valueLabel ? $this->_valueLabel : 'Value'),
 					'choices'  => $this->_valueChoice,
 					'required' => true,
-					'attr'     => array(
+					'attr'     => [
 						'data-help-key' => $valueHelpKey,
-					),
+					],
+					'constraints' => [
+						new Constraints\NotBlank
+					]
 				)
 			);
 		} else {
 			$builder->add('value', 'text',
-				array(
+				[
 					'label'    => ($this->_valueLabel ? $this->_valueLabel : 'Value'),
-					'attr'  => array(
+					'attr'  => [
 						'data-help-key' => $valueHelpKey,
-					)
-				)
+						'placeholder' => "e.g. 'Red, Blue'",
+					],
+					'constraints' => [
+						new Constraints\NotBlank
+					]
+				]
 			);
 		}
 
@@ -92,14 +104,14 @@ class OptionType extends AbstractType {
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
 
-    	$resolver->setDefaults(array(
-            'attr' => array(
-            	'data-help-key' => array(
+    	$resolver->setDefaults([
+            'attr' => [
+            	'data-help-key' => [
             		'name'  => '',
             		'value' => ''
-            	)
-            )
-        ));
+            	]
+            ]
+        ]);
     }
 
 	public function getName()

--- a/src/Product/Form/UnitAdd.php
+++ b/src/Product/Form/UnitAdd.php
@@ -35,16 +35,10 @@ class UnitAdd extends AbstractType
 				'placeholder' 	=> 'ms.commerce.product.units.sku.placeholder',
 				'data-help-key' => 'ms.commerce.product.image.option.units.sku.help',
 			],
-			'constraints' => [
-				new NotBlank,
-			],
 		])
 		->add('weight', 'number', [
 			'attr' => [
 				'data-help-key' => 'ms.commerce.product.details.weight-grams.help',
-			],
-			'constraints' => [
-				new NotBlank,
 			],
 		]);
 
@@ -53,7 +47,7 @@ class UnitAdd extends AbstractType
 				'data-help-key' => [
 					'name'  => 'ms.commerce.product.units.option.name.help',
 					'value' => 'ms.commerce.product.units.option.value.help',
-				]
+				],
 		]]);
 
 		$optionType

--- a/src/Product/Unit/Create.php
+++ b/src/Product/Unit/Create.php
@@ -63,7 +63,7 @@ class Create
 			'visible'	=> (bool) $unit->visible,
 			'barcode'	=> $unit->barcode,
 			'sup_ref'	=> $unit->supplierRef,
-			'weight'	=> $unit->weight,
+			'weight'	=> $unit->weight ?: $unit->product->weight,
 			'createdAt' => $unit->authorship->createdAt(),
 			'createdBy' => $unit->authorship->createdBy()->id,
 		]);

--- a/src/Product/Unit/Create.php
+++ b/src/Product/Unit/Create.php
@@ -55,7 +55,7 @@ class Create
 					(SELECT AUTO_INCREMENT FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='product_unit')
 				),
 				supplier_ref = :sup_ref?sn,
-				weight_grams = :weight?i,
+				weight_grams = :weight?in,
 				created_at   = :createdAt?d,
 				created_by   = :createdBy?i
 		", [
@@ -63,7 +63,7 @@ class Create
 			'visible'	=> (bool) $unit->visible,
 			'barcode'	=> $unit->barcode,
 			'sup_ref'	=> $unit->supplierRef,
-			'weight'	=> $unit->weight ?: $unit->product->weight,
+			'weight'	=> $unit->weight,
 			'createdAt' => $unit->authorship->createdAt(),
 			'createdBy' => $unit->authorship->createdBy()->id,
 		]);


### PR DESCRIPTION
This PR makes adding units a bit simpler/clearer. Changes made:

+ SKU is no longer required, defaults to unit ID
+ Weight is no longer required, defaults to product weight
+ Option name and value are both required
+ Added placeholder text to option name and value
+ Stock form no longer shows units with invalid options