### PR TITLE
Do not throw exception if payment is zero

### DIFF
--- a/src/Payment/Create.php
+++ b/src/Payment/Create.php
@@ -118,8 +118,8 @@ class Create implements DB\TransactionalInterface
 
 	protected function _validate(Payment $payment)
 	{
-		if ($payment->amount <= 0) {
-			throw new InvalidArgumentException('Could not create payment: amount must be greater than 0');
+		if ($payment->amount < 0) {
+			throw new InvalidArgumentException('Could not create payment: amount must be 0 or greater');
 		}
 
 		if (!$payment->currencyID) {


### PR DESCRIPTION
This PR resolves the issue where zero payment orders would not be created because this exception was thrown. It potentially makes more sense to just not create the payment object but I feel this way is safer