### PR TITLE
Actual price default value as null

### DIFF
--- a/src/Order/Entity/Item/EventListener.php
+++ b/src/Order/Entity/Item/EventListener.php
@@ -88,7 +88,7 @@ class EventListener implements SubscriberInterface
 		}
 
 		foreach ($items as $item) {
-			if (!$item->actualPrice) {
+			if ($item->actualPrice === null) {
 				$item->actualPrice = $item->listPrice;
 			}
 		}

--- a/src/Order/Entity/Item/Item.php
+++ b/src/Order/Entity/Item/Item.php
@@ -26,7 +26,7 @@ class Item implements EntityInterface, RecordInterface
 	public $status;
 
 	public $listPrice          = 0; // Retail price of the item as advertised
-	public $actualPrice        = 0; // Same as list price unless it was overriden
+	public $actualPrice        = null; // Same as list price unless it was overriden
 	public $basePrice          = 0; // Price of the item for this order (before discounts) (actual price with or without tax, as appropriate)
 	public $net                = 0; // Net amount, calculated on discounted price
 	public $discount           = 0; // Discount amount for this item


### PR DESCRIPTION
Changes the "default" value of `actualPrice` to `null` so that the actualPrice may be set to 0 without defaulting. Test this extensively, including how it gets stored to the db.