### PR TITLE
Populate add unit form with submitted data if invalid

### DIFF
--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -659,7 +659,6 @@ class Edit extends Controller
 	 */
 	protected function _addNewUnitForm()
 	{
-
 		$data = $this->get('http.session')->get(self::UNIT_DATA) ?: [];
 
 		$form = $this->createForm($this->get('product.form.unit.add'), $data, [

--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -659,16 +659,17 @@ class Edit extends Controller
 	 */
 	protected function _addNewUnitForm()
 	{
-		$form = $this->createForm($this->get('product.form.unit.add'), null, [
+
+		$data = $this->get('http.session')->get(self::UNIT_DATA) ?: [];
+
+		$form = $this->createForm($this->get('product.form.unit.add'), $data, [
 			'action' => $this->generateUrl('ms.commerce.product.edit.units.create.action', [
 				'productID' => $this->_product->id,
 			]),
+			'data' => $data,
 		]);
 
-		$data = $this->get('http.session')->get(self::UNIT_DATA);
-
 		if ($data) {
-			$form->setData($data);
 			$this->get('http.session')->remove(self::UNIT_DATA);
 		}
 

--- a/src/Form/Extension/Type/PriceForm.php
+++ b/src/Form/Extension/Type/PriceForm.php
@@ -20,12 +20,14 @@ class PriceForm extends AbstractType
 	{
 		$entity   = $options['priced_entity'];
 		if ($entity !== null && !$entity instanceof PricedInterface) {
-			throw new \IllegalArgumentException('Option `priced_entity` must be instance of PricedInterface');
+			throw new \InvalidArgumentException('Option `priced_entity` must be instance of PricedInterface');
 		}
 
 		$priceData = [];
+		$currencyData = !empty($options['data']) && !empty($options['data']['currencies']) ? $options['data']['currencies'] : [];
 
 		$currencyCollection = $builder->create('currencies', 'form', ['label' => false,]);
+
 		foreach ($options['currencies'] as $currency) {
 			if ($entity) {	
 				foreach($entity->getPrices() as $type => $price) {
@@ -41,6 +43,10 @@ class PriceForm extends AbstractType
 				'label'    => $currency,
 				'pricing'  => $entity ? $priceData : null,
 			];
+
+			if (!empty($currencyData[$currency])) {
+				$currCollOptions['data'] = $currencyData[$currency];
+			}
 
 			if (isset($options['constraints'])) {
 				$currCollOptions['constraints'] = $options['constraints'];

--- a/src/Form/Extension/Type/PriceGroup.php
+++ b/src/Form/Extension/Type/PriceGroup.php
@@ -19,13 +19,20 @@ class PriceGroup extends Form\AbstractType
 	{
 		$priceTypes = $options['price_types'];
 		$currency   = $options['currency'];
+
 		foreach ($priceTypes as $type => $value) {
+			if (!empty($options['data']) && !empty($options['data'][$type])) {
+				$data = $options['data'][$type];
+			} else {
+				$data = isset($options['pricing'][$type]) ? $options['pricing'][$type] : $options['default'];
+			}
+
 			$value = $value ?: 0;
 
 			$fieldOpts = [
 				'currency' => $currency,
 				'label'    => "ms.commerce.product.pricing.$type.label",
-				'data'     => isset($options['pricing'][$type]) ? $options['pricing'][$type] : $options['default'],
+				'data'     => $data,
 				'attr'     => [
 					'class' => 'price-field',
 				]

--- a/src/Product/Form/ProductPricing.php
+++ b/src/Product/Form/ProductPricing.php
@@ -9,7 +9,6 @@ use Message\Mothership\Commerce\Product\Product;
 
 class ProductPricing extends AbstractType
 {
-
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
 		$product   = $options['product'];

--- a/src/Product/Form/UnitAdd.php
+++ b/src/Product/Form/UnitAdd.php
@@ -72,7 +72,13 @@ class UnitAdd extends AbstractType
 			]
 		);
 
-		$builder->add('prices', 'price_form');
+		if (!empty($options['data']) && !empty($options['data']['prices'])) {
+			$data = $options['data']['prices'];
+		} else {
+			$data = [];
+		}
+
+		$builder->add('prices', 'price_form', ['data' => $data]);
 	}
 
 	/**

--- a/src/Product/Form/UnitAdd.php
+++ b/src/Product/Form/UnitAdd.php
@@ -5,7 +5,7 @@ namespace Message\Mothership\Commerce\Product\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints;
 use Message\Mothership\Commerce\Product\OptionLoader;
 use Message\Mothership\Commerce\Field\OptionType;
 use Message\Mothership\Commerce\Constraint\Product\UnitHasOptions;
@@ -36,10 +36,17 @@ class UnitAdd extends AbstractType
 				'data-help-key' => 'ms.commerce.product.image.option.units.sku.help',
 			],
 		])
-		->add('weight', 'number', [
+		->add('weight', 'text', [
+			'label' => 'ms.commerce.product.details.weight-grams.label',
 			'attr' => [
 				'data-help-key' => 'ms.commerce.product.details.weight-grams.help',
 			],
+			'constraints' => [
+				new Constraints\Type([
+					'type' => 'numeric',
+					'message' => 'Must be numeric',
+				]),
+			]
 		]);
 
 		$optionType = new OptionType($headings, [

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -101,8 +101,10 @@ ms.commerce:
         label: Supplier Reference
         help: Optionally you can store a reference from the supplier of this product.
       weight-grams:
-        label: Weight Grams
+        label: Weight (g)
         help: This field can be used to calculate shipping costs, depending on your delivery preferences.
+        error:
+          numeric: Must be numeric
       fabric:
         label: Fabric
         help:

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -103,8 +103,6 @@ ms.commerce:
       weight-grams:
         label: Weight (g)
         help: This field can be used to calculate shipping costs, depending on your delivery preferences.
-        error:
-          numeric: Must be numeric
       fabric:
         label: Fabric
         help:


### PR DESCRIPTION
This PR closes #381. Annoyingly, the data would be dropped if it was a string when the form was the `number` type, so I changed it to string and added a constraint to it. I also set a custom error message because 'Value must be of type numeric' is a dreadful, dreadful error message
