### PR TITLE
Fix unit loader load invisible

### DIFF
--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -266,7 +266,7 @@ class Loader implements ProductEntityLoaderInterface
 		;
 
 		if (!$this->_loadInvisible) {
-			$this->_queryBuilder->where('product_unit.visible = ?i', [0]);
+			$this->_queryBuilder->where('product_unit.visible = ?i', [1]);
 		}
 
 		if (!$this->_loadOutOfStock) {


### PR DESCRIPTION
Not loading invisible means only loading visible. So product_unit.visible should be 1.