### PR TITLE
Cancel event

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -996,6 +996,10 @@ class Services implements ServicesInterface
 		$services['order.basket.token'] = $services->factory(function($c) {
 			return new Commerce\Order\Basket\Token($c['user.password_hash'], $c['cfg']);
 		});
+
+		$services['gateway'] = $services->factory(function ($c) {
+			throw new \LogicException('`gateway` service does not exist in `cog-mothership-commerce`. Relying on soft dependency of `cog-mothership-ecommerce` to process refund.');
+		});
 	}
 
 	public function registerEmails($services)

--- a/src/Controller/Order/Cancel/Cancel.php
+++ b/src/Controller/Order/Cancel/Cancel.php
@@ -105,11 +105,11 @@ class Cancel extends Controller
 
 				if ($refundable && true === $form->get('refund')->getData()) {
 
-					$payable = new Order\CancellationRefund($this->_order);
-					$payable->setPayableAmount($refundAmount);
-					$payable->setTax($this->_order->totalTax);
+					$refund = new Order\CancellationRefund($this->_order);
+					$refund->setPayableAmount($refundAmount);
+					$refund->setTax($this->_order->totalTax);
 
-					$event = new CancelEvent($this->_order, $payable);
+					$event = new CancelEvent($this->_order, $refund);
 					$this->get('event.dispatcher')->dispatch(
 						Events::ORDER_CANCEL_REFUND,
 						$event
@@ -124,7 +124,7 @@ class Cancel extends Controller
 					$controller = 'Message:Mothership:Commerce::Controller:Order:Cancel:Refund';
 
 					return $this->forward($this->get('gateway')->getRefundControllerReference(), [
-						'payable'   => $payable,
+						'payable'   => $refund,
 						'reference' => $this->_getPaymentReference(),
 						'stages'    => [
 							'failure' => $controller . '#orderFailure',
@@ -218,11 +218,11 @@ class Cancel extends Controller
 				$this->_addFlashes();
 
 				if ($refundable && true === $form->get('refund')->getData()) {
-					$payable = new Order\CancellationRefund($this->_order);
-					$payable->setPayableAmount($item->gross);
-					$payable->setTax($item->getTax());
+					$refund = new Order\CancellationRefund($this->_order);
+					$refund->setPayableAmount($item->gross);
+					$refund->setTax($item->getTax());
 
-					$event = new CancelEvent($this->_order, $payable);
+					$event = new CancelEvent($this->_order, $refund);
 					$this->get('event.dispatcher')->dispatch(
 						Events::ITEM_CANCEL_REFUND,
 						$event
@@ -237,7 +237,7 @@ class Cancel extends Controller
 					$controller = 'Message:Mothership:Commerce::Controller:Order:Cancel:Refund';
 
 					return $this->forward($this->get('gateway')->getRefundControllerReference(), [
-						'payable'   => $payable,
+						'payable'   => $refund,
 						'reference' => $this->_getPaymentReference(),
 						'stages'    => [
 							'failure' => $controller . '#itemFailure',

--- a/src/Controller/Order/Cancel/Cancel.php
+++ b/src/Controller/Order/Cancel/Cancel.php
@@ -117,10 +117,12 @@ class Cancel extends Controller
 
 					$forward = $event->getControllerReference();
 
+					// $forward should exist if e-commerce module is up to date. If not, default to old behaviour.
 					if ($forward) {
 						return $this->forward($forward, $event->getParams());
 					}
 
+					trigger_error('Using deprecated refund code, please ensure you `cog-mothership-ecommerce` installation is version 3.7.0 or higher', E_USER_DEPRECATED);
 					$controller = 'Message:Mothership:Commerce::Controller:Order:Cancel:Refund';
 
 					return $this->forward($this->get('gateway')->getRefundControllerReference(), [
@@ -230,10 +232,12 @@ class Cancel extends Controller
 
 					$forward = $event->getControllerReference();
 
+					// $forward should exist if e-commerce module is up to date. If not, default to old behaviour.
 					if ($forward) {
 						return $this->forward($forward, $event->getParams());
 					}
 
+					trigger_error('Using deprecated refund code, please ensure you `cog-mothership-ecommerce` installation is version 3.7.0 or higher', E_USER_DEPRECATED);
 					$controller = 'Message:Mothership:Commerce::Controller:Order:Cancel:Refund';
 
 					return $this->forward($this->get('gateway')->getRefundControllerReference(), [
@@ -359,6 +363,10 @@ class Cancel extends Controller
 		return ($payment ? $payment->reference : null);
 	}
 
+	/**
+	 * @todo remove necessity for this method, this module should not have any references to e-commerce module
+	 * @return bool
+	 */
 	protected function _doesEcommerceExist()
 	{
 		$exists = true;

--- a/src/Controller/Order/Cancel/Cancel.php
+++ b/src/Controller/Order/Cancel/Cancel.php
@@ -122,7 +122,7 @@ class Cancel extends Controller
 						return $this->forward($forward, $event->getParams());
 					}
 
-					trigger_error('Using deprecated refund code, please ensure you `cog-mothership-ecommerce` installation is version 3.7.0 or higher', E_USER_DEPRECATED);
+					trigger_error('Using deprecated refund code, please ensure `cog-mothership-ecommerce` installation is version 3.7.0 or higher', E_USER_DEPRECATED);
 					$controller = 'Message:Mothership:Commerce::Controller:Order:Cancel:Refund';
 
 					return $this->forward($this->get('gateway')->getRefundControllerReference(), [
@@ -237,7 +237,7 @@ class Cancel extends Controller
 						return $this->forward($forward, $event->getParams());
 					}
 
-					trigger_error('Using deprecated refund code, please ensure you `cog-mothership-ecommerce` installation is version 3.7.0 or higher', E_USER_DEPRECATED);
+					trigger_error('Using deprecated refund code, please ensure `cog-mothership-ecommerce` installation is version 3.7.0 or higher', E_USER_DEPRECATED);
 					$controller = 'Message:Mothership:Commerce::Controller:Order:Cancel:Refund';
 
 					return $this->forward($this->get('gateway')->getRefundControllerReference(), [

--- a/src/Order/Event/CancelEvent.php
+++ b/src/Order/Event/CancelEvent.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Message\Mothership\Commerce\Order\Event;
+
+use Message\Mothership\Commerce\Order;
+use Message\Mothership\Commerce\Payable\PayableInterface;
+
+class CancelEvent extends Event
+{
+	private $_controllerReference;
+	private $_params = [];
+	private $_payable;
+
+	public function __construct(Order\Order $order, PayableInterface $payable)
+	{
+		parent::__construct($order);
+		$this->_payable = $payable;
+	}
+
+	public function setControllerReference($reference)
+	{
+		if (!is_string($reference)) {
+			throw new \InvalidArgumentException('Reference must be a string, ' .gettype($reference) . ' given');
+		}
+
+		$this->_controllerReference = $reference;
+	}
+
+	public function getControllerReference()
+	{
+		return $this->_controllerReference;
+	}
+
+	public function setParams(array $params)
+	{
+		$this->_params = $params;
+	}
+
+	public function getParams()
+	{
+		return $this->_params;
+	}
+
+	public function setPayable(PayableInterface $payable)
+	{
+		$this->_payable = $payable;
+	}
+
+	public function getPayable()
+	{
+		return $this->_payable;
+	}
+}

--- a/src/Order/Event/CancelEvent.php
+++ b/src/Order/Event/CancelEvent.php
@@ -3,20 +3,47 @@
 namespace Message\Mothership\Commerce\Order\Event;
 
 use Message\Mothership\Commerce\Order;
-use Message\Mothership\Commerce\Payable\PayableInterface;
 
+/**
+ * Class CancelEvent
+ * @package Message\Mothership\Commerce\Order\Event
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Event to allow other modules (e.g. E-commerce) to determine how to process a refund.
+ */
 class CancelEvent extends Event
 {
+	/**
+	 * @var string
+	 */
 	private $_controllerReference;
-	private $_params = [];
-	private $_payable;
 
-	public function __construct(Order\Order $order, PayableInterface $payable)
+	/**
+	 * @var array
+	 */
+	private $_params = [];
+
+	/**
+	 * @var Order\CancellationRefund
+	 */
+	private $_refund;
+
+	/**
+	 * @param Order\Order $order
+	 * @param Order\CancellationRefund $refund
+	 */
+	public function __construct(Order\Order $order, Order\CancellationRefund $refund)
 	{
 		parent::__construct($order);
-		$this->_payable = $payable;
+		$this->_refund = $refund;
 	}
 
+	/**
+	 * Set the reference for the controller that handles the refund
+	 *
+	 * @param $reference
+	 */
 	public function setControllerReference($reference)
 	{
 		if (!is_string($reference)) {
@@ -26,28 +53,53 @@ class CancelEvent extends Event
 		$this->_controllerReference = $reference;
 	}
 
+	/**
+	 * Get the reference for the controller that handles the refund
+	 *
+	 * @return string
+	 */
 	public function getControllerReference()
 	{
 		return $this->_controllerReference;
 	}
 
+	/**
+	 * Set the parameters for the controller that handles the refund
+	 *
+	 * @param array $params
+	 */
 	public function setParams(array $params)
 	{
 		$this->_params = $params;
 	}
 
+	/**
+	 * Get the parameters for the controller that handles the refund
+	 *
+	 * @return array
+	 */
 	public function getParams()
 	{
 		return $this->_params;
 	}
 
-	public function setPayable(PayableInterface $payable)
+	/**
+	 * Set the refund object
+	 *
+	 * @param Order\CancellationRefund $refund
+	 */
+	public function setRefund(Order\CancellationRefund $refund)
 	{
-		$this->_payable = $payable;
+		$this->_refund = $refund;
 	}
 
-	public function getPayable()
+	/**
+	 * Get the refund object
+	 *
+	 * @return Order\CancellationRefund
+	 */
+	public function getRefund()
 	{
-		return $this->_payable;
+		return $this->_refund;
 	}
 }

--- a/src/Order/Events.php
+++ b/src/Order/Events.php
@@ -18,6 +18,8 @@ final class Events
 	const DISPATCH_POSTAGE_AUTO = 'commerce.order.dispatch.postage.automatically';
 	const DISPATCH_SHIPPED      = 'commerce.order.dispatch.shipped';
 	const DISPATCH_NOTIFICATION = 'commerce.order.dispatch.notification';
+	const ORDER_CANCEL_REFUND   = 'commerce.order.cancel.refund';
+	const ITEM_CANCEL_REFUND    = 'commerce.order.item.cancel.refund';
 
 	const ENTITY_CREATE         = 'commerce.order.entity.create';
 	const ENTITY_CREATE_END     = 'commerce.order.entity.create.end';


### PR DESCRIPTION
This PR fires an event when an order is cancelled. This allows us to begin to move some of the functionality to E-commerce where it belongs. The order and the refund object are assigned to the new `CancelEvent` object, and when the event is fired, if a controller reference and parameters are assigned to it by another module, it will use those to process the refund. Otherwise, it will use the old approach. However, now the `gateway` service throws an exception if called from Commerce, so if for some reason E-commerce isn't installed, we will get a more useful error.