### PR TITLE
Do not allow for lower case option names on images

### DIFF
--- a/resources/migrations/_1449670331_MakeImageOptionLowerCase.php
+++ b/resources/migrations/_1449670331_MakeImageOptionLowerCase.php
@@ -1,0 +1,22 @@
+<?php
+
+use Message\Cog\Migration\Adapter\MySQL\Migration;
+
+class _1449670331_MakeImageOptionLowerCase extends Migration
+{
+	public function up()
+	{
+		$this->run("
+			UPDATE
+				product_image_option
+			SET
+				`name` = LOWER(`name`)
+			;
+		");
+	}
+
+	public function down()
+	{
+		// Cannot be rolled back
+	}
+}

--- a/src/Product/Image/Image.php
+++ b/src/Product/Image/Image.php
@@ -9,8 +9,6 @@ use Message\ImageResize\ResizableInterface;
 
 use Message\Cog\ValueObject\Authorship;
 
-use Exception;
-
 /**
  * Class Image
  * @package Message\Mothership\Commerce\Product\Image
@@ -35,18 +33,38 @@ class Image implements ResizableInterface
 	public $type;
 
 	/**
-	 * @var
+	 * @var \Message\Cog\Localisation\Locale
 	 */
 	public $locale;
+
+	/**
+	 * @var int
+	 */
 	public $fileID;
+
+	/**
+	 * @var \Message\Mothership\Commerce\Product\Product
+	 */
 	public $product;
 
+	/**
+	 * @var File
+	 */
 	protected $_file;
 
+	/**
+	 * @var FileLoader
+	 */
 	protected $_fileLoader;
 
+	/**
+	 * @var array
+	 */
 	private $_options = [];
 
+	/**
+	 *
+	 */
 	public function __construct()
 	{
 		$this->authorship = new Authorship;
@@ -55,35 +73,65 @@ class Image implements ResizableInterface
 			->disableUpdate(); // remove when making update class
 	}
 
+	/**
+	 * Magic getter is parse by reference to allow backwards compatibility access to previously public `$_options`
+	 * property
+	 *
+	 * @param $key
+	 *
+	 * @return array|File
+	 */
 	public function &__get($key)
 	{
-		if ('file' == $key) {
-			if (null === $this->_file) {
-				$this->_loadFile();
-			}
+		switch ($key) {
+			case 'file' :
+				if (null === $this->_file) {
+					$this->_loadFile();
+				}
 
-			return $this->_file;
-		}
+				return $this->_file;
+			case 'options' :
+				$this->_options = $this->_cleanOptions($this->_options);
 
-		if ('options' == $key) {
-			$this->_options = $this->_cleanOptions($this->_options);
-
-			return $this->_options;
+				return $this->_options;
 		}
 	}
 
+	/**
+	 * Magic setter for setting file and options as if they were public
+	 *
+	 * @param $key
+	 * @param $value
+	 */
 	public function __set($key, $value)
 	{
-		if ('options' === $key) {
-			$this->setOptions($value);
+		switch ($key) {
+			case 'file' :
+				$this->_setFile($value);
+				break;
+			case 'options' :
+				$this->setOptions($value);
+				break;
+			default:
+				$this->$key = $value;
 		}
 	}
 
+	/**
+	 * @param $key
+	 *
+	 * @return bool
+	 */
 	public function __isset($key)
 	{
 		return ('file' === $key);
 	}
 
+	/**
+	 * Load file and drop file loader on serialization
+	 *
+	 * @return array
+	 */
 	public function __sleep()
 	{
 		$this->_loadFile();
@@ -100,6 +148,9 @@ class Image implements ResizableInterface
 		);
 	}
 
+	/**
+	 * @return string | null
+	 */
 	public function getUrl()
 	{
 		if (!$this->getFile()) {
@@ -109,6 +160,9 @@ class Image implements ResizableInterface
 		return $this->getFile()->getUrl();
 	}
 
+	/**
+	 * @return string | null
+	 */
 	public function getAltText()
 	{
 		if (!$this->getFile()) {
@@ -118,21 +172,33 @@ class Image implements ResizableInterface
 		return $this->getFile()->getAltText();
 	}
 
+	/**
+	 * @param FileLoader $fileLoader
+	 */
 	public function setFileLoader(FileLoader $fileLoader)
 	{
 		$this->_fileLoader = $fileLoader;
 	}
 
+	/**
+	 * @param array $options
+	 */
 	public function setOptions(array $options)
 	{
 		$this->_options = $this->_cleanOptions($options);
 	}
 
+	/**
+	 * @return array
+	 */
 	public function getOptions()
 	{
 		return $this->_options;
 	}
 
+	/**
+	 * @return File
+	 */
 	public function getFile()
 	{
 		if (null === $this->_file) {
@@ -142,6 +208,9 @@ class Image implements ResizableInterface
 		return $this->_file;
 	}
 
+	/**
+	 * Load the file if it has not already been loaded
+	 */
 	protected function _loadFile()
 	{
 		if (null !== $this->_file) {
@@ -155,6 +224,13 @@ class Image implements ResizableInterface
 		$this->_file = $this->_fileLoader->getByID($this->fileID);
 	}
 
+	/**
+	 * Parse options. All keys should be lower case to be consistent with product options.
+	 *
+	 * @param $options
+	 *
+	 * @return array
+	 */
 	private function _cleanOptions($options)
 	{
 		$clean = [];
@@ -169,5 +245,13 @@ class Image implements ResizableInterface
 		}
 
 		return $clean;
+	}
+
+	/**
+	 * @param File $file
+	 */
+	private function _setFile(File $file)
+	{
+		$this->_file = $file;
 	}
 }


### PR DESCRIPTION
This PR fixes the issue where image option names could have variable casing, whereas on product units they would always be lower case. This would mean that if an image option had a name of 'Colour' instead of 'colour', it would cause the image to not load on cross sells etc.
