### PR TITLE
Fix invisible unit loading issue

### DIFF
--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -266,7 +266,7 @@ class Loader implements ProductEntityLoaderInterface
 		;
 
 		if (!$this->_loadInvisible) {
-			$this->_queryBuilder->where('product_unit.visible = ?i', [0]);
+			$this->_queryBuilder->where('product_unit.visible = ?b', [true]);
 		}
 
 		if (!$this->_loadOutOfStock) {


### PR DESCRIPTION
The unit loader was doing the exact opposite of what it should do if you call `includeInvisible(false)`, and *only* loading invisible units and not loading any others. This PR fixes that.