### PR TITLE
Add getBySupplier() method to product loader

### DIFF
--- a/src/Product/Loader.php
+++ b/src/Product/Loader.php
@@ -186,6 +186,25 @@ class Loader implements EntityLoaderInterface
 		return $this->_loadProduct($result->flatten(), $limit);
 	}
 
+
+	public function getBySupplier($supplier, $limit = null)
+	{
+		$this->_checkLimit($limit);
+
+		$result = $this->_query->run('
+			SELECT
+				product_id
+			FROM
+				product
+			WHERE
+				supplier_ref = ?s
+		', [
+			$supplier
+		]);
+
+		return $this->_loadProduct($result->flatten(), $limit);
+	}
+
 	public function getByType($type)
 	{
 		$result = $this->_query->run("


### PR DESCRIPTION
This PR adds a `getBySupplier()` method to the product loader. It makes me a bit sad though because it reminds me that the product loader could use a refactor to use the query builder, to load products with significantly fewer queries as well as allowing for easy filtering