### PR TITLE
Set actual price as list price on order items

### DIFF
--- a/src/Order/Entity/Item/Item.php
+++ b/src/Order/Entity/Item/Item.php
@@ -93,6 +93,7 @@ class Item implements EntityInterface, RecordInterface
 		if ($this->order instanceof Order) {
 			$this->listPrice   = $unit->getPrice('retail', $this->order->currencyID);
 			$this->rrp         = $unit->getPrice('rrp', $this->order->currencyID);
+			$this->actualPrice = $this->actualPrice ?: $this->listPrice;
 		}
 
 		$this->productTaxRate  = (float) $product->getTaxRates()->getTotalTaxRate();


### PR DESCRIPTION
This PR fixes an issue where sometimes an item would be valued at 0 if the currency is changed.