### PR TITLE
Fix edit classes

### DIFF
--- a/src/Controller/Product/Edit.php
+++ b/src/Controller/Product/Edit.php
@@ -294,8 +294,6 @@ class Edit extends Controller
 			$productEdit = $this->get('product.edit');
 			$productEdit->setTransaction($trans);
 
-			$product->authorship->update(new DateTimeImmutable, $this->get('user.current'));
-
 			$product->name                        = $data['name'];
 			$product->shortDescription            = $data['short_description'];
 			$product->displayName                 = $data['display_name'];
@@ -347,8 +345,6 @@ class Edit extends Controller
 			$productEdit = $this->get('product.edit');
 			$productEdit->setTransaction($trans);
 
-			$product->authorship->update(new DateTimeImmutable, $this->get('user.current'));
-
 			$product->setDetails($detailEdit->updateDetails($data, $product->getDetails()));
 			$detailEdit->save($product);
 
@@ -379,7 +375,6 @@ class Edit extends Controller
 		if ($form->isValid() && $data = $form->getData()) {
 			$product = $this->_product;
 
-			$product->authorship->update(new DateTimeImmutable, $this->get('user.current'));
 			$product->exportValue                = $data['export_value'];
 			//set prices on the product
 			foreach($data['prices']['currencies'] as $currency => $typePrices) {

--- a/src/Product/Edit.php
+++ b/src/Product/Edit.php
@@ -64,6 +64,8 @@ class Edit implements TransactionalInterface
 	{
 		$this->_product = $product;
 
+		$product->authorship->update(null, $this->_user);
+
 		$this->_saveProduct()
 			->_saveProductInfo()
 			->_saveProductExport();

--- a/src/Product/Unit/Edit.php
+++ b/src/Product/Unit/Edit.php
@@ -107,6 +107,10 @@ class Edit implements DB\TransactionalInterface
 			));
 		}
 
+		if ($this->_query instanceof DB\Transaction) {
+			return $unit;
+		}
+
 		return $result->affected() ? $unit : false;
 	}
 


### PR DESCRIPTION
So there were a couple of bugs in the Edit classes. The unit edit class would attempt to call `affected()` on the DB transaction class, even though it doesn't exist, causing a fatal error. Also for some reason the product authorship didn't seem to be getting updated before saving the product.