### PR TITLE
Save value against unit in upload, not key

### DIFF
--- a/src/Product/Upload/UnitBuilder.php
+++ b/src/Product/Upload/UnitBuilder.php
@@ -121,7 +121,7 @@ class UnitBuilder
 		foreach ($row as $key => $value) {
 			$key = $this->_headingKeys->getKey($key);
 			if ($value && property_exists($this->_unit, $key)) {
-				$this->_unit->$key = $key;
+				$this->_unit->$key = $value;
 			}
 		}
 


### PR DESCRIPTION
So, this issue is bigger than it originally seemed. The weights weren't saving properly, but it turns out what was actually happen was the key of the array was being saved instead of the value, i.e. the weight was being saved as 'weight'.