### PR TITLE
Do not load units for deleted products in unit loader

### DIFF
--- a/src/Product/Unit/Loader.php
+++ b/src/Product/Unit/Loader.php
@@ -274,7 +274,9 @@ class Loader implements ProductEntityLoaderInterface
 		}
 
 		if (!$this->_loadDeleted) {
-			$this->_queryBuilder->where('product_unit.deleted_at IS NULL');
+			$this->_queryBuilder->where('product_unit.deleted_at IS NULL')
+				->where('product.deleted_at IS NULL')
+			;
 		}
 	}
 


### PR DESCRIPTION
This PR prevents product units from being loaded by the unit loader if the product has been deleted. A unit might not have been explicitly marked as deleted, even though the unit has. This mostly isn't a problem but it means that a unit can be loaded in EPOS, and then it throws an error because the product _hasn't_ been loaded.
