### PR TITLE
Improved error reporting on product upload

### DIFF
--- a/src/Bootstrap/Routes.php
+++ b/src/Bootstrap/Routes.php
@@ -83,7 +83,6 @@ class Routes implements RoutesInterface
 		$router['ms.product']->add('ms.commerce.product.edit.stock', 'edit/{productID}/stock', 'Message:Mothership:Commerce::Controller:Product:Edit#stock')
 			->setRequirement('productID', '\d+');
 
-
 		$router['ms.product']->add('ms.commerce.product.edit.images.action', 'edit/{productID}/images', 'Message:Mothership:Commerce::Controller:Product:Edit#processImage')
 			->setRequirement('productID', '\d+')
 			->setMethod('POST');

--- a/src/Controller/Product/CsvPort.php
+++ b/src/Controller/Product/CsvPort.php
@@ -117,7 +117,7 @@ class CsvPort extends Controller
 					}
 				}
 				catch (UploadFrontEndException $e) {
-					$this->addFlash('error', $e->getMessage());
+					$this->addFlash('error', $e->getTranslation(), $e->getParams());
 				}
 			}
 

--- a/src/Product/Upload/Exception/UploadFrontEndException.php
+++ b/src/Product/Upload/Exception/UploadFrontEndException.php
@@ -2,5 +2,7 @@
 
 namespace Message\Mothership\Commerce\Product\Upload\Exception;
 
-class UploadFrontEndException extends \Exception
+use Message\Cog\Exception\TranslationLogicException;
+
+class UploadFrontEndException extends TranslationLogicException
 {}

--- a/src/Product/Upload/ProductBuilder.php
+++ b/src/Product/Upload/ProductBuilder.php
@@ -137,6 +137,7 @@ class ProductBuilder
 					}
 					$productType = $this->_productTypes->get($type);
 					$this->_product->type = $productType;
+					break;
 				}
 			}
 		}

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -185,6 +185,7 @@ ms.commerce:
       description: The upload CSV function will create products based on the data that has been uploaded. Please ensure that this data is correct. It will check which columns have been filled and attempt to work out the product type based on that information.
       utf8-note: <strong>Note:</strong> CSVs must have a character encoding of UTF-8, please see the preferences of your spreadsheet software to ensure this is the case.
       no-valid-rows: Could not detect any rows. Note that when exporting the CSV via your spreadsheet software, you must select UTF-8 as the character encoding format. Unfortunately, this is not currently supported by the OS X version of Microsoft Excel.
+      build-fail: Could not create product `%productName%`, for the following reason: '%message%'
       image:
         error: Could not assign image to product with the name '%productName%' for the following reason: %message%
       csv:


### PR DESCRIPTION
This PR adds better error reporting when a product hasn't been created during the product upload. It will now show users the actual exception message to get a better idea of what was wrong. An exception will also be thrown if data exists for multiple product types on one product row