### PR TITLE
Ignore voided orders in sales reports

### DIFF
--- a/src/Report/AppendQuery/Sales.php
+++ b/src/Report/AppendQuery/Sales.php
@@ -53,6 +53,14 @@ class Sales implements FilterableInterface
 	{
 		$data = $this->_builderFactory->getQueryBuilder();
 
+		$voids = $this->_builderFactory->getQueryBuilder()
+			->select('transaction_record.record_id', true)
+			->from('transaction')
+			->joinUsing('transaction_record', 'transaction_id')
+			->where('transaction.type = ?s', ['order'])
+			->where('transaction.voided_at IS NOT NULL')
+		;
+
 		$data
 			->select('item.created_at AS "Date"')
 			->select('order_summary.currency_id AS "Currency"')
@@ -81,6 +89,7 @@ class Sales implements FilterableInterface
 			->where('product.type != "voucher"')
 			->where('order_summary.status_code >= 0')
 			->where('return_item.exchange_item_id IS NULL')
+			->where('item.order_id NOT IN (?q)', [$voids]) // Exclude voided orders
 		;
 
 		// Filter dates

--- a/src/Report/AppendQuery/Sales.php
+++ b/src/Report/AppendQuery/Sales.php
@@ -57,7 +57,7 @@ class Sales implements FilterableInterface
 			->select('transaction_record.record_id', true)
 			->from('transaction')
 			->joinUsing('transaction_record', 'transaction_id')
-			->where('transaction.type = ?s', ['order'])
+			->where('transaction_record.type = ?s', ['order'])
 			->where('transaction.voided_at IS NOT NULL')
 		;
 
@@ -88,6 +88,7 @@ class Sales implements FilterableInterface
 			->leftJoin('product', 'item.product_id = product.product_id')
 			->where('product.type != "voucher"')
 			->where('order_summary.status_code >= 0')
+			->where('order_summary.deleted_at IS NULL')
 			->where('return_item.exchange_item_id IS NULL')
 			->where('item.order_id NOT IN (?q)', [$voids]) // Exclude voided orders
 		;

--- a/src/Report/AppendQuery/Shipping.php
+++ b/src/Report/AppendQuery/Shipping.php
@@ -74,6 +74,7 @@ class Shipping implements FilterableInterface
 			->join('order_summary', 'order_shipping.order_id = order_summary.order_id')
 			->leftJoin('order_address', 'order_summary.order_id = order_address.order_id AND order_address.type = "delivery"') // AND order_address.deleted_at IS NULL
 			->leftJoin('user', 'order_summary.user_id = user.user_id')
+			->where('order_summary.deleted_at IS NULL')
 			->where('order_summary.status_code >= 0')
 		;
 


### PR DESCRIPTION
This PR appends the sales report query to ignore voided orders. It's possible that in the future we might want to add a filter for this, but as it stands I don't really see a reason to include these sales, since voiding them effectively makes them not exist

See also https://github.com/mothership-ec/cog-mothership-returns/pull/200