### PR TITLE
Do not override product type with basic on product upload

### DIFF
--- a/src/Product/Upload/ProductBuilder.php
+++ b/src/Product/Upload/ProductBuilder.php
@@ -137,11 +137,11 @@ class ProductBuilder
 					}
 					$productType = $this->_productTypes->get($type);
 					$this->_product->type = $productType;
-					break;
+					$this->_setDetails($data);
+					return;
 				}
 			}
 		}
-		$this->_setDetails($data);
 
 		$this->_product->type = $this->_productTypes->getDefault();
 	}


### PR DESCRIPTION
The product upload feature guesses the product type based on the fields that have been filled out in the product upload spreadsheet. I'm not sure how I managed to miss this when testing the changes before, but after detecting the type, it gets overridden to the default type. This fix ensures that the method gets returned as soon as the product type has been set to prevent this from happening.